### PR TITLE
fix(server.po): recover email string translations

### DIFF
--- a/locale/af/LC_MESSAGES/server.po
+++ b/locale/af/LC_MESSAGES/server.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-02-20 19:15+0000\n"
+"POT-Creation-Date: 2015-02-25 18:58+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "Language: \n"
@@ -15,7 +15,8 @@ msgstr ""
 #: server/templates/pages/src/503.html:1
 #: server/templates/pages/src/index.html:1
 #: server/templates/pages/src/privacy.html:1
-#: server/templates/pages/src/terms.html:1
+#: server/templates/pages/src/terms.html:1 templates/reset.html:1
+#: templates/unlock.html:1 templates/verify.html:1
 msgid "Firefox Accounts"
 msgstr ""
 
@@ -87,4 +88,68 @@ msgstr ""
 #: server/templates/pages/src/terms.html:2
 #: server/templates/pages/src/terms.html:5
 msgid "Terms of Service"
+msgstr ""
+
+#: templates/reset.html:2 templates/reset.txt:1
+msgid "Are you sure?"
+msgstr ""
+
+#: templates/reset.html:3 templates/reset.txt:2
+msgid "Please confirm that you'd like to reset the password for %(email)s."
+msgstr ""
+
+#: templates/reset.html:4
+msgid "Reset password"
+msgstr ""
+
+#: templates/reset.html:5 templates/reset.txt:4 templates/unlock.html:4
+#: templates/unlock.txt:3 templates/verify.html:5 templates/verify.txt:4
+msgid ""
+"This is an automated email; if you received it in error, no action is "
+"required."
+msgstr ""
+
+#: templates/reset.html:6 templates/unlock.html:5 templates/verify.html:6
+msgid ""
+"For more information, please visit <a href='https://support.mozilla."
+"org'>Mozilla Support</a>"
+msgstr ""
+
+#: templates/reset.txt:3
+msgid "Reset password:"
+msgstr ""
+
+#: templates/reset.txt:5 templates/unlock.txt:4 templates/verify.txt:5
+msgid "For more information, please visit https://support.mozilla.org"
+msgstr ""
+
+#: templates/unlock.html:2 templates/unlock.txt:1
+msgid ""
+"For security reasons your Firefox Account was put on lockdown. To perform "
+"account-level activities, please click the link to re-verify your account "
+"now."
+msgstr ""
+
+#: templates/unlock.html:3
+msgid "Verify account"
+msgstr ""
+
+#: templates/unlock.txt:2
+msgid "Verify account:"
+msgstr ""
+
+#: templates/verify.html:2 templates/verify.txt:1
+msgid "Almost there"
+msgstr ""
+
+#: templates/verify.html:3 templates/verify.txt:2
+msgid "%(email)s, you're one click away from verifying your Firefox Account."
+msgstr ""
+
+#: templates/verify.html:4
+msgid "Verify"
+msgstr ""
+
+#: templates/verify.txt:3
+msgid "Verify:"
 msgstr ""

--- a/locale/an/LC_MESSAGES/server.po
+++ b/locale/an/LC_MESSAGES/server.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-02-20 19:15+0000\n"
+"POT-Creation-Date: 2015-02-25 18:58+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "Language: \n"
@@ -15,7 +15,8 @@ msgstr ""
 #: server/templates/pages/src/503.html:1
 #: server/templates/pages/src/index.html:1
 #: server/templates/pages/src/privacy.html:1
-#: server/templates/pages/src/terms.html:1
+#: server/templates/pages/src/terms.html:1 templates/reset.html:1
+#: templates/unlock.html:1 templates/verify.html:1
 msgid "Firefox Accounts"
 msgstr ""
 
@@ -87,4 +88,68 @@ msgstr ""
 #: server/templates/pages/src/terms.html:2
 #: server/templates/pages/src/terms.html:5
 msgid "Terms of Service"
+msgstr ""
+
+#: templates/reset.html:2 templates/reset.txt:1
+msgid "Are you sure?"
+msgstr ""
+
+#: templates/reset.html:3 templates/reset.txt:2
+msgid "Please confirm that you'd like to reset the password for %(email)s."
+msgstr ""
+
+#: templates/reset.html:4
+msgid "Reset password"
+msgstr ""
+
+#: templates/reset.html:5 templates/reset.txt:4 templates/unlock.html:4
+#: templates/unlock.txt:3 templates/verify.html:5 templates/verify.txt:4
+msgid ""
+"This is an automated email; if you received it in error, no action is "
+"required."
+msgstr ""
+
+#: templates/reset.html:6 templates/unlock.html:5 templates/verify.html:6
+msgid ""
+"For more information, please visit <a href='https://support.mozilla."
+"org'>Mozilla Support</a>"
+msgstr ""
+
+#: templates/reset.txt:3
+msgid "Reset password:"
+msgstr ""
+
+#: templates/reset.txt:5 templates/unlock.txt:4 templates/verify.txt:5
+msgid "For more information, please visit https://support.mozilla.org"
+msgstr ""
+
+#: templates/unlock.html:2 templates/unlock.txt:1
+msgid ""
+"For security reasons your Firefox Account was put on lockdown. To perform "
+"account-level activities, please click the link to re-verify your account "
+"now."
+msgstr ""
+
+#: templates/unlock.html:3
+msgid "Verify account"
+msgstr ""
+
+#: templates/unlock.txt:2
+msgid "Verify account:"
+msgstr ""
+
+#: templates/verify.html:2 templates/verify.txt:1
+msgid "Almost there"
+msgstr ""
+
+#: templates/verify.html:3 templates/verify.txt:2
+msgid "%(email)s, you're one click away from verifying your Firefox Account."
+msgstr ""
+
+#: templates/verify.html:4
+msgid "Verify"
+msgstr ""
+
+#: templates/verify.txt:3
+msgid "Verify:"
 msgstr ""

--- a/locale/ar/LC_MESSAGES/server.po
+++ b/locale/ar/LC_MESSAGES/server.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-02-20 19:15+0000\n"
+"POT-Creation-Date: 2015-02-25 18:58+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "Language: \n"
@@ -15,7 +15,8 @@ msgstr ""
 #: server/templates/pages/src/503.html:1
 #: server/templates/pages/src/index.html:1
 #: server/templates/pages/src/privacy.html:1
-#: server/templates/pages/src/terms.html:1
+#: server/templates/pages/src/terms.html:1 templates/reset.html:1
+#: templates/unlock.html:1 templates/verify.html:1
 msgid "Firefox Accounts"
 msgstr ""
 
@@ -87,4 +88,68 @@ msgstr ""
 #: server/templates/pages/src/terms.html:2
 #: server/templates/pages/src/terms.html:5
 msgid "Terms of Service"
+msgstr ""
+
+#: templates/reset.html:2 templates/reset.txt:1
+msgid "Are you sure?"
+msgstr ""
+
+#: templates/reset.html:3 templates/reset.txt:2
+msgid "Please confirm that you'd like to reset the password for %(email)s."
+msgstr ""
+
+#: templates/reset.html:4
+msgid "Reset password"
+msgstr ""
+
+#: templates/reset.html:5 templates/reset.txt:4 templates/unlock.html:4
+#: templates/unlock.txt:3 templates/verify.html:5 templates/verify.txt:4
+msgid ""
+"This is an automated email; if you received it in error, no action is "
+"required."
+msgstr ""
+
+#: templates/reset.html:6 templates/unlock.html:5 templates/verify.html:6
+msgid ""
+"For more information, please visit <a href='https://support.mozilla."
+"org'>Mozilla Support</a>"
+msgstr ""
+
+#: templates/reset.txt:3
+msgid "Reset password:"
+msgstr ""
+
+#: templates/reset.txt:5 templates/unlock.txt:4 templates/verify.txt:5
+msgid "For more information, please visit https://support.mozilla.org"
+msgstr ""
+
+#: templates/unlock.html:2 templates/unlock.txt:1
+msgid ""
+"For security reasons your Firefox Account was put on lockdown. To perform "
+"account-level activities, please click the link to re-verify your account "
+"now."
+msgstr ""
+
+#: templates/unlock.html:3
+msgid "Verify account"
+msgstr ""
+
+#: templates/unlock.txt:2
+msgid "Verify account:"
+msgstr ""
+
+#: templates/verify.html:2 templates/verify.txt:1
+msgid "Almost there"
+msgstr ""
+
+#: templates/verify.html:3 templates/verify.txt:2
+msgid "%(email)s, you're one click away from verifying your Firefox Account."
+msgstr ""
+
+#: templates/verify.html:4
+msgid "Verify"
+msgstr ""
+
+#: templates/verify.txt:3
+msgid "Verify:"
 msgstr ""

--- a/locale/as/LC_MESSAGES/server.po
+++ b/locale/as/LC_MESSAGES/server.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-02-20 19:15+0000\n"
+"POT-Creation-Date: 2015-02-25 18:58+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "Language: \n"
@@ -15,7 +15,8 @@ msgstr ""
 #: server/templates/pages/src/503.html:1
 #: server/templates/pages/src/index.html:1
 #: server/templates/pages/src/privacy.html:1
-#: server/templates/pages/src/terms.html:1
+#: server/templates/pages/src/terms.html:1 templates/reset.html:1
+#: templates/unlock.html:1 templates/verify.html:1
 msgid "Firefox Accounts"
 msgstr ""
 
@@ -87,4 +88,68 @@ msgstr ""
 #: server/templates/pages/src/terms.html:2
 #: server/templates/pages/src/terms.html:5
 msgid "Terms of Service"
+msgstr ""
+
+#: templates/reset.html:2 templates/reset.txt:1
+msgid "Are you sure?"
+msgstr ""
+
+#: templates/reset.html:3 templates/reset.txt:2
+msgid "Please confirm that you'd like to reset the password for %(email)s."
+msgstr ""
+
+#: templates/reset.html:4
+msgid "Reset password"
+msgstr ""
+
+#: templates/reset.html:5 templates/reset.txt:4 templates/unlock.html:4
+#: templates/unlock.txt:3 templates/verify.html:5 templates/verify.txt:4
+msgid ""
+"This is an automated email; if you received it in error, no action is "
+"required."
+msgstr ""
+
+#: templates/reset.html:6 templates/unlock.html:5 templates/verify.html:6
+msgid ""
+"For more information, please visit <a href='https://support.mozilla."
+"org'>Mozilla Support</a>"
+msgstr ""
+
+#: templates/reset.txt:3
+msgid "Reset password:"
+msgstr ""
+
+#: templates/reset.txt:5 templates/unlock.txt:4 templates/verify.txt:5
+msgid "For more information, please visit https://support.mozilla.org"
+msgstr ""
+
+#: templates/unlock.html:2 templates/unlock.txt:1
+msgid ""
+"For security reasons your Firefox Account was put on lockdown. To perform "
+"account-level activities, please click the link to re-verify your account "
+"now."
+msgstr ""
+
+#: templates/unlock.html:3
+msgid "Verify account"
+msgstr ""
+
+#: templates/unlock.txt:2
+msgid "Verify account:"
+msgstr ""
+
+#: templates/verify.html:2 templates/verify.txt:1
+msgid "Almost there"
+msgstr ""
+
+#: templates/verify.html:3 templates/verify.txt:2
+msgid "%(email)s, you're one click away from verifying your Firefox Account."
+msgstr ""
+
+#: templates/verify.html:4
+msgid "Verify"
+msgstr ""
+
+#: templates/verify.txt:3
+msgid "Verify:"
 msgstr ""

--- a/locale/ast/LC_MESSAGES/server.po
+++ b/locale/ast/LC_MESSAGES/server.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-02-20 19:15+0000\n"
+"POT-Creation-Date: 2015-02-25 18:58+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "Language: \n"
@@ -15,7 +15,8 @@ msgstr ""
 #: server/templates/pages/src/503.html:1
 #: server/templates/pages/src/index.html:1
 #: server/templates/pages/src/privacy.html:1
-#: server/templates/pages/src/terms.html:1
+#: server/templates/pages/src/terms.html:1 templates/reset.html:1
+#: templates/unlock.html:1 templates/verify.html:1
 msgid "Firefox Accounts"
 msgstr ""
 
@@ -87,4 +88,68 @@ msgstr ""
 #: server/templates/pages/src/terms.html:2
 #: server/templates/pages/src/terms.html:5
 msgid "Terms of Service"
+msgstr ""
+
+#: templates/reset.html:2 templates/reset.txt:1
+msgid "Are you sure?"
+msgstr ""
+
+#: templates/reset.html:3 templates/reset.txt:2
+msgid "Please confirm that you'd like to reset the password for %(email)s."
+msgstr ""
+
+#: templates/reset.html:4
+msgid "Reset password"
+msgstr ""
+
+#: templates/reset.html:5 templates/reset.txt:4 templates/unlock.html:4
+#: templates/unlock.txt:3 templates/verify.html:5 templates/verify.txt:4
+msgid ""
+"This is an automated email; if you received it in error, no action is "
+"required."
+msgstr ""
+
+#: templates/reset.html:6 templates/unlock.html:5 templates/verify.html:6
+msgid ""
+"For more information, please visit <a href='https://support.mozilla."
+"org'>Mozilla Support</a>"
+msgstr ""
+
+#: templates/reset.txt:3
+msgid "Reset password:"
+msgstr ""
+
+#: templates/reset.txt:5 templates/unlock.txt:4 templates/verify.txt:5
+msgid "For more information, please visit https://support.mozilla.org"
+msgstr ""
+
+#: templates/unlock.html:2 templates/unlock.txt:1
+msgid ""
+"For security reasons your Firefox Account was put on lockdown. To perform "
+"account-level activities, please click the link to re-verify your account "
+"now."
+msgstr ""
+
+#: templates/unlock.html:3
+msgid "Verify account"
+msgstr ""
+
+#: templates/unlock.txt:2
+msgid "Verify account:"
+msgstr ""
+
+#: templates/verify.html:2 templates/verify.txt:1
+msgid "Almost there"
+msgstr ""
+
+#: templates/verify.html:3 templates/verify.txt:2
+msgid "%(email)s, you're one click away from verifying your Firefox Account."
+msgstr ""
+
+#: templates/verify.html:4
+msgid "Verify"
+msgstr ""
+
+#: templates/verify.txt:3
+msgid "Verify:"
 msgstr ""

--- a/locale/az/LC_MESSAGES/server.po
+++ b/locale/az/LC_MESSAGES/server.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-02-20 19:15+0000\n"
+"POT-Creation-Date: 2015-02-25 18:58+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,7 +17,8 @@ msgstr ""
 #: server/templates/pages/src/503.html:1
 #: server/templates/pages/src/index.html:1
 #: server/templates/pages/src/privacy.html:1
-#: server/templates/pages/src/terms.html:1
+#: server/templates/pages/src/terms.html:1 templates/reset.html:1
+#: templates/unlock.html:1 templates/verify.html:1
 msgid "Firefox Accounts"
 msgstr ""
 
@@ -89,4 +90,68 @@ msgstr ""
 #: server/templates/pages/src/terms.html:2
 #: server/templates/pages/src/terms.html:5
 msgid "Terms of Service"
+msgstr ""
+
+#: templates/reset.html:2 templates/reset.txt:1
+msgid "Are you sure?"
+msgstr ""
+
+#: templates/reset.html:3 templates/reset.txt:2
+msgid "Please confirm that you'd like to reset the password for %(email)s."
+msgstr ""
+
+#: templates/reset.html:4
+msgid "Reset password"
+msgstr ""
+
+#: templates/reset.html:5 templates/reset.txt:4 templates/unlock.html:4
+#: templates/unlock.txt:3 templates/verify.html:5 templates/verify.txt:4
+msgid ""
+"This is an automated email; if you received it in error, no action is "
+"required."
+msgstr ""
+
+#: templates/reset.html:6 templates/unlock.html:5 templates/verify.html:6
+msgid ""
+"For more information, please visit <a href='https://support.mozilla."
+"org'>Mozilla Support</a>"
+msgstr ""
+
+#: templates/reset.txt:3
+msgid "Reset password:"
+msgstr ""
+
+#: templates/reset.txt:5 templates/unlock.txt:4 templates/verify.txt:5
+msgid "For more information, please visit https://support.mozilla.org"
+msgstr ""
+
+#: templates/unlock.html:2 templates/unlock.txt:1
+msgid ""
+"For security reasons your Firefox Account was put on lockdown. To perform "
+"account-level activities, please click the link to re-verify your account "
+"now."
+msgstr ""
+
+#: templates/unlock.html:3
+msgid "Verify account"
+msgstr ""
+
+#: templates/unlock.txt:2
+msgid "Verify account:"
+msgstr ""
+
+#: templates/verify.html:2 templates/verify.txt:1
+msgid "Almost there"
+msgstr ""
+
+#: templates/verify.html:3 templates/verify.txt:2
+msgid "%(email)s, you're one click away from verifying your Firefox Account."
+msgstr ""
+
+#: templates/verify.html:4
+msgid "Verify"
+msgstr ""
+
+#: templates/verify.txt:3
+msgid "Verify:"
 msgstr ""

--- a/locale/be/LC_MESSAGES/server.po
+++ b/locale/be/LC_MESSAGES/server.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-02-20 19:15+0000\n"
+"POT-Creation-Date: 2015-02-25 18:58+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "Language: \n"
@@ -15,7 +15,8 @@ msgstr ""
 #: server/templates/pages/src/503.html:1
 #: server/templates/pages/src/index.html:1
 #: server/templates/pages/src/privacy.html:1
-#: server/templates/pages/src/terms.html:1
+#: server/templates/pages/src/terms.html:1 templates/reset.html:1
+#: templates/unlock.html:1 templates/verify.html:1
 msgid "Firefox Accounts"
 msgstr ""
 
@@ -87,4 +88,68 @@ msgstr ""
 #: server/templates/pages/src/terms.html:2
 #: server/templates/pages/src/terms.html:5
 msgid "Terms of Service"
+msgstr ""
+
+#: templates/reset.html:2 templates/reset.txt:1
+msgid "Are you sure?"
+msgstr ""
+
+#: templates/reset.html:3 templates/reset.txt:2
+msgid "Please confirm that you'd like to reset the password for %(email)s."
+msgstr ""
+
+#: templates/reset.html:4
+msgid "Reset password"
+msgstr ""
+
+#: templates/reset.html:5 templates/reset.txt:4 templates/unlock.html:4
+#: templates/unlock.txt:3 templates/verify.html:5 templates/verify.txt:4
+msgid ""
+"This is an automated email; if you received it in error, no action is "
+"required."
+msgstr ""
+
+#: templates/reset.html:6 templates/unlock.html:5 templates/verify.html:6
+msgid ""
+"For more information, please visit <a href='https://support.mozilla."
+"org'>Mozilla Support</a>"
+msgstr ""
+
+#: templates/reset.txt:3
+msgid "Reset password:"
+msgstr ""
+
+#: templates/reset.txt:5 templates/unlock.txt:4 templates/verify.txt:5
+msgid "For more information, please visit https://support.mozilla.org"
+msgstr ""
+
+#: templates/unlock.html:2 templates/unlock.txt:1
+msgid ""
+"For security reasons your Firefox Account was put on lockdown. To perform "
+"account-level activities, please click the link to re-verify your account "
+"now."
+msgstr ""
+
+#: templates/unlock.html:3
+msgid "Verify account"
+msgstr ""
+
+#: templates/unlock.txt:2
+msgid "Verify account:"
+msgstr ""
+
+#: templates/verify.html:2 templates/verify.txt:1
+msgid "Almost there"
+msgstr ""
+
+#: templates/verify.html:3 templates/verify.txt:2
+msgid "%(email)s, you're one click away from verifying your Firefox Account."
+msgstr ""
+
+#: templates/verify.html:4
+msgid "Verify"
+msgstr ""
+
+#: templates/verify.txt:3
+msgid "Verify:"
 msgstr ""

--- a/locale/bg/LC_MESSAGES/server.po
+++ b/locale/bg/LC_MESSAGES/server.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-02-20 19:15+0000\n"
+"POT-Creation-Date: 2015-02-25 18:58+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,7 +17,8 @@ msgstr ""
 #: server/templates/pages/src/503.html:1
 #: server/templates/pages/src/index.html:1
 #: server/templates/pages/src/privacy.html:1
-#: server/templates/pages/src/terms.html:1
+#: server/templates/pages/src/terms.html:1 templates/reset.html:1
+#: templates/unlock.html:1 templates/verify.html:1
 msgid "Firefox Accounts"
 msgstr ""
 
@@ -89,4 +90,68 @@ msgstr ""
 #: server/templates/pages/src/terms.html:2
 #: server/templates/pages/src/terms.html:5
 msgid "Terms of Service"
+msgstr ""
+
+#: templates/reset.html:2 templates/reset.txt:1
+msgid "Are you sure?"
+msgstr ""
+
+#: templates/reset.html:3 templates/reset.txt:2
+msgid "Please confirm that you'd like to reset the password for %(email)s."
+msgstr ""
+
+#: templates/reset.html:4
+msgid "Reset password"
+msgstr ""
+
+#: templates/reset.html:5 templates/reset.txt:4 templates/unlock.html:4
+#: templates/unlock.txt:3 templates/verify.html:5 templates/verify.txt:4
+msgid ""
+"This is an automated email; if you received it in error, no action is "
+"required."
+msgstr ""
+
+#: templates/reset.html:6 templates/unlock.html:5 templates/verify.html:6
+msgid ""
+"For more information, please visit <a href='https://support.mozilla."
+"org'>Mozilla Support</a>"
+msgstr ""
+
+#: templates/reset.txt:3
+msgid "Reset password:"
+msgstr ""
+
+#: templates/reset.txt:5 templates/unlock.txt:4 templates/verify.txt:5
+msgid "For more information, please visit https://support.mozilla.org"
+msgstr ""
+
+#: templates/unlock.html:2 templates/unlock.txt:1
+msgid ""
+"For security reasons your Firefox Account was put on lockdown. To perform "
+"account-level activities, please click the link to re-verify your account "
+"now."
+msgstr ""
+
+#: templates/unlock.html:3
+msgid "Verify account"
+msgstr ""
+
+#: templates/unlock.txt:2
+msgid "Verify account:"
+msgstr ""
+
+#: templates/verify.html:2 templates/verify.txt:1
+msgid "Almost there"
+msgstr ""
+
+#: templates/verify.html:3 templates/verify.txt:2
+msgid "%(email)s, you're one click away from verifying your Firefox Account."
+msgstr ""
+
+#: templates/verify.html:4
+msgid "Verify"
+msgstr ""
+
+#: templates/verify.txt:3
+msgid "Verify:"
 msgstr ""

--- a/locale/bn_BD/LC_MESSAGES/server.po
+++ b/locale/bn_BD/LC_MESSAGES/server.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-02-20 19:15+0000\n"
+"POT-Creation-Date: 2015-02-25 18:58+0000\n"
 "PO-Revision-Date: 2014-10-22 04:46+0000\n"
 "Last-Translator: Tapu <tapu_afrad@hotmail.com>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -19,7 +19,8 @@ msgstr ""
 #: server/templates/pages/src/503.html:1
 #: server/templates/pages/src/index.html:1
 #: server/templates/pages/src/privacy.html:1
-#: server/templates/pages/src/terms.html:1
+#: server/templates/pages/src/terms.html:1 templates/reset.html:1
+#: templates/unlock.html:1 templates/verify.html:1
 msgid "Firefox Accounts"
 msgstr "ফায়ারফক্স অ্যাকাউন্টস"
 
@@ -102,50 +103,77 @@ msgstr "ফায়ারফক্স ক্লাউড সেবা সমূহ
 msgid "Terms of Service"
 msgstr "সেবার শর্ত সমূহ"
 
-#~ msgid "Are you sure?"
-#~ msgstr "আপনি নিশ্চিত?"
+#: templates/reset.html:2 templates/reset.txt:1
+msgid "Are you sure?"
+msgstr "আপনি নিশ্চিত?"
 
-#~ msgid "Please confirm that you'd like to reset the password for %(email)s."
-#~ msgstr ""
-#~ "অনুগ্রহ করে নিশ্চিত করুন যে আপনি %(email)s এর জন্য পাসওয়ার্ড রিসেট করতে চান।"
+#: templates/reset.html:3 templates/reset.txt:2
+msgid "Please confirm that you'd like to reset the password for %(email)s."
+msgstr "অনুগ্রহ করে নিশ্চিত করুন যে আপনি %(email)s এর জন্য পাসওয়ার্ড রিসেট করতে চান।"
 
-#~ msgid "Reset password"
-#~ msgstr "রিসেট পাসওয়ার্ড"
+#: templates/reset.html:4
+msgid "Reset password"
+msgstr "রিসেট পাসওয়ার্ড"
 
-#~ msgid ""
-#~ "This is an automated email; if you received it in error, no action is "
-#~ "required."
-#~ msgstr ""
-#~ "এটি একটি স্বয়ংক্রিয় ইমেইল; যদি কোন ত্রুটির কারনে আপনি এটি পেয়ে থাকেন, কিছু "
-#~ "করার প্রয়োজন নেই।"
+#: templates/reset.html:5 templates/reset.txt:4 templates/unlock.html:4
+#: templates/unlock.txt:3 templates/verify.html:5 templates/verify.txt:4
+msgid ""
+"This is an automated email; if you received it in error, no action is "
+"required."
+msgstr ""
+"এটি একটি স্বয়ংক্রিয় ইমেইল; যদি কোন ত্রুটির কারনে আপনি এটি পেয়ে থাকেন, কিছু করার "
+"প্রয়োজন নেই।"
 
-#~ msgid ""
-#~ "For more information, please visit <a href='https://support.mozilla."
-#~ "org'>Mozilla Support</a>"
-#~ msgstr ""
-#~ "আরও তথ্যের জন্য অনুগ্রহ করে <a href='https://support.mozilla.org'>মজিলা "
-#~ "সহায়তা সাইট</a> ভিজিট করুন।"
+#: templates/reset.html:6 templates/unlock.html:5 templates/verify.html:6
+msgid ""
+"For more information, please visit <a href='https://support.mozilla."
+"org'>Mozilla Support</a>"
+msgstr ""
+"আরও তথ্যের জন্য অনুগ্রহ করে <a href='https://support.mozilla.org'>মজিলা সহায়তা "
+"সাইট</a> ভিজিট করুন।"
 
-#~ msgid "Reset password:"
-#~ msgstr "পাসওয়ার্ড রিসেট:"
+#: templates/reset.txt:3
+msgid "Reset password:"
+msgstr "পাসওয়ার্ড রিসেট:"
 
-#~ msgid "For more information, please visit https://support.mozilla.org"
-#~ msgstr "আরও তথ্যের জন্য অনুগ্রহ করে https://support.mozilla.org ভিজিট করুন"
+#: templates/reset.txt:5 templates/unlock.txt:4 templates/verify.txt:5
+msgid "For more information, please visit https://support.mozilla.org"
+msgstr "আরও তথ্যের জন্য অনুগ্রহ করে https://support.mozilla.org ভিজিট করুন"
+
+#: templates/unlock.html:2 templates/unlock.txt:1
+msgid ""
+"For security reasons your Firefox Account was put on lockdown. To perform "
+"account-level activities, please click the link to re-verify your account "
+"now."
+msgstr ""
+
+#: templates/unlock.html:3
+msgid "Verify account"
+msgstr ""
+
+#: templates/unlock.txt:2
+msgid "Verify account:"
+msgstr ""
+
+#: templates/verify.html:2 templates/verify.txt:1
+msgid "Almost there"
+msgstr ""
+
+#: templates/verify.html:3 templates/verify.txt:2
+msgid "%(email)s, you're one click away from verifying your Firefox Account."
+msgstr ""
+"%(email)s, আপনি আপনার ফায়ারফক্স অ্যাকাউন্ট নিশ্চিত করা থেকে একটি ক্লিক দূরে আছেন।"
+
+#: templates/verify.html:4
+msgid "Verify"
+msgstr "নিশ্চিত"
+
+#: templates/verify.txt:3
+msgid "Verify:"
+msgstr "নিশ্চিত:"
 
 #~ msgid "Congratulations!"
 #~ msgstr "অভিনন্দন!"
-
-#~ msgid ""
-#~ "%(email)s, you're one click away from verifying your Firefox Account."
-#~ msgstr ""
-#~ "%(email)s, আপনি আপনার ফায়ারফক্স অ্যাকাউন্ট নিশ্চিত করা থেকে একটি ক্লিক দূরে "
-#~ "আছেন।"
-
-#~ msgid "Verify"
-#~ msgstr "নিশ্চিত"
-
-#~ msgid "Verify:"
-#~ msgstr "নিশ্চিত:"
 
 #~ msgid "Verify your account"
 #~ msgstr "আপনার অ্যাকাউন্ট নিশ্চিত করুন"

--- a/locale/bn_IN/LC_MESSAGES/server.po
+++ b/locale/bn_IN/LC_MESSAGES/server.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-02-20 19:15+0000\n"
+"POT-Creation-Date: 2015-02-25 18:58+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,7 +17,8 @@ msgstr ""
 #: server/templates/pages/src/503.html:1
 #: server/templates/pages/src/index.html:1
 #: server/templates/pages/src/privacy.html:1
-#: server/templates/pages/src/terms.html:1
+#: server/templates/pages/src/terms.html:1 templates/reset.html:1
+#: templates/unlock.html:1 templates/verify.html:1
 msgid "Firefox Accounts"
 msgstr ""
 
@@ -89,4 +90,68 @@ msgstr ""
 #: server/templates/pages/src/terms.html:2
 #: server/templates/pages/src/terms.html:5
 msgid "Terms of Service"
+msgstr ""
+
+#: templates/reset.html:2 templates/reset.txt:1
+msgid "Are you sure?"
+msgstr ""
+
+#: templates/reset.html:3 templates/reset.txt:2
+msgid "Please confirm that you'd like to reset the password for %(email)s."
+msgstr ""
+
+#: templates/reset.html:4
+msgid "Reset password"
+msgstr ""
+
+#: templates/reset.html:5 templates/reset.txt:4 templates/unlock.html:4
+#: templates/unlock.txt:3 templates/verify.html:5 templates/verify.txt:4
+msgid ""
+"This is an automated email; if you received it in error, no action is "
+"required."
+msgstr ""
+
+#: templates/reset.html:6 templates/unlock.html:5 templates/verify.html:6
+msgid ""
+"For more information, please visit <a href='https://support.mozilla."
+"org'>Mozilla Support</a>"
+msgstr ""
+
+#: templates/reset.txt:3
+msgid "Reset password:"
+msgstr ""
+
+#: templates/reset.txt:5 templates/unlock.txt:4 templates/verify.txt:5
+msgid "For more information, please visit https://support.mozilla.org"
+msgstr ""
+
+#: templates/unlock.html:2 templates/unlock.txt:1
+msgid ""
+"For security reasons your Firefox Account was put on lockdown. To perform "
+"account-level activities, please click the link to re-verify your account "
+"now."
+msgstr ""
+
+#: templates/unlock.html:3
+msgid "Verify account"
+msgstr ""
+
+#: templates/unlock.txt:2
+msgid "Verify account:"
+msgstr ""
+
+#: templates/verify.html:2 templates/verify.txt:1
+msgid "Almost there"
+msgstr ""
+
+#: templates/verify.html:3 templates/verify.txt:2
+msgid "%(email)s, you're one click away from verifying your Firefox Account."
+msgstr ""
+
+#: templates/verify.html:4
+msgid "Verify"
+msgstr ""
+
+#: templates/verify.txt:3
+msgid "Verify:"
 msgstr ""

--- a/locale/br/LC_MESSAGES/server.po
+++ b/locale/br/LC_MESSAGES/server.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-02-20 19:15+0000\n"
+"POT-Creation-Date: 2015-02-25 18:58+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "Language: \n"
@@ -15,7 +15,8 @@ msgstr ""
 #: server/templates/pages/src/503.html:1
 #: server/templates/pages/src/index.html:1
 #: server/templates/pages/src/privacy.html:1
-#: server/templates/pages/src/terms.html:1
+#: server/templates/pages/src/terms.html:1 templates/reset.html:1
+#: templates/unlock.html:1 templates/verify.html:1
 msgid "Firefox Accounts"
 msgstr ""
 
@@ -87,4 +88,68 @@ msgstr ""
 #: server/templates/pages/src/terms.html:2
 #: server/templates/pages/src/terms.html:5
 msgid "Terms of Service"
+msgstr ""
+
+#: templates/reset.html:2 templates/reset.txt:1
+msgid "Are you sure?"
+msgstr ""
+
+#: templates/reset.html:3 templates/reset.txt:2
+msgid "Please confirm that you'd like to reset the password for %(email)s."
+msgstr ""
+
+#: templates/reset.html:4
+msgid "Reset password"
+msgstr ""
+
+#: templates/reset.html:5 templates/reset.txt:4 templates/unlock.html:4
+#: templates/unlock.txt:3 templates/verify.html:5 templates/verify.txt:4
+msgid ""
+"This is an automated email; if you received it in error, no action is "
+"required."
+msgstr ""
+
+#: templates/reset.html:6 templates/unlock.html:5 templates/verify.html:6
+msgid ""
+"For more information, please visit <a href='https://support.mozilla."
+"org'>Mozilla Support</a>"
+msgstr ""
+
+#: templates/reset.txt:3
+msgid "Reset password:"
+msgstr ""
+
+#: templates/reset.txt:5 templates/unlock.txt:4 templates/verify.txt:5
+msgid "For more information, please visit https://support.mozilla.org"
+msgstr ""
+
+#: templates/unlock.html:2 templates/unlock.txt:1
+msgid ""
+"For security reasons your Firefox Account was put on lockdown. To perform "
+"account-level activities, please click the link to re-verify your account "
+"now."
+msgstr ""
+
+#: templates/unlock.html:3
+msgid "Verify account"
+msgstr ""
+
+#: templates/unlock.txt:2
+msgid "Verify account:"
+msgstr ""
+
+#: templates/verify.html:2 templates/verify.txt:1
+msgid "Almost there"
+msgstr ""
+
+#: templates/verify.html:3 templates/verify.txt:2
+msgid "%(email)s, you're one click away from verifying your Firefox Account."
+msgstr ""
+
+#: templates/verify.html:4
+msgid "Verify"
+msgstr ""
+
+#: templates/verify.txt:3
+msgid "Verify:"
 msgstr ""

--- a/locale/bs/LC_MESSAGES/server.po
+++ b/locale/bs/LC_MESSAGES/server.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-02-20 19:15+0000\n"
+"POT-Creation-Date: 2015-02-25 18:58+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "Language: \n"
@@ -15,7 +15,8 @@ msgstr ""
 #: server/templates/pages/src/503.html:1
 #: server/templates/pages/src/index.html:1
 #: server/templates/pages/src/privacy.html:1
-#: server/templates/pages/src/terms.html:1
+#: server/templates/pages/src/terms.html:1 templates/reset.html:1
+#: templates/unlock.html:1 templates/verify.html:1
 msgid "Firefox Accounts"
 msgstr ""
 
@@ -87,4 +88,68 @@ msgstr ""
 #: server/templates/pages/src/terms.html:2
 #: server/templates/pages/src/terms.html:5
 msgid "Terms of Service"
+msgstr ""
+
+#: templates/reset.html:2 templates/reset.txt:1
+msgid "Are you sure?"
+msgstr ""
+
+#: templates/reset.html:3 templates/reset.txt:2
+msgid "Please confirm that you'd like to reset the password for %(email)s."
+msgstr ""
+
+#: templates/reset.html:4
+msgid "Reset password"
+msgstr ""
+
+#: templates/reset.html:5 templates/reset.txt:4 templates/unlock.html:4
+#: templates/unlock.txt:3 templates/verify.html:5 templates/verify.txt:4
+msgid ""
+"This is an automated email; if you received it in error, no action is "
+"required."
+msgstr ""
+
+#: templates/reset.html:6 templates/unlock.html:5 templates/verify.html:6
+msgid ""
+"For more information, please visit <a href='https://support.mozilla."
+"org'>Mozilla Support</a>"
+msgstr ""
+
+#: templates/reset.txt:3
+msgid "Reset password:"
+msgstr ""
+
+#: templates/reset.txt:5 templates/unlock.txt:4 templates/verify.txt:5
+msgid "For more information, please visit https://support.mozilla.org"
+msgstr ""
+
+#: templates/unlock.html:2 templates/unlock.txt:1
+msgid ""
+"For security reasons your Firefox Account was put on lockdown. To perform "
+"account-level activities, please click the link to re-verify your account "
+"now."
+msgstr ""
+
+#: templates/unlock.html:3
+msgid "Verify account"
+msgstr ""
+
+#: templates/unlock.txt:2
+msgid "Verify account:"
+msgstr ""
+
+#: templates/verify.html:2 templates/verify.txt:1
+msgid "Almost there"
+msgstr ""
+
+#: templates/verify.html:3 templates/verify.txt:2
+msgid "%(email)s, you're one click away from verifying your Firefox Account."
+msgstr ""
+
+#: templates/verify.html:4
+msgid "Verify"
+msgstr ""
+
+#: templates/verify.txt:3
+msgid "Verify:"
 msgstr ""

--- a/locale/ca/LC_MESSAGES/server.po
+++ b/locale/ca/LC_MESSAGES/server.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-02-20 19:15+0000\n"
+"POT-Creation-Date: 2015-02-25 18:58+0000\n"
 "PO-Revision-Date: 2014-04-28 08:41+0000\n"
 "Last-Translator: Eduard <edu@eduard-gamonal.net>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -19,7 +19,8 @@ msgstr ""
 #: server/templates/pages/src/503.html:1
 #: server/templates/pages/src/index.html:1
 #: server/templates/pages/src/privacy.html:1
-#: server/templates/pages/src/terms.html:1
+#: server/templates/pages/src/terms.html:1 templates/reset.html:1
+#: templates/unlock.html:1 templates/verify.html:1
 msgid "Firefox Accounts"
 msgstr "Comptes del Firefox"
 
@@ -95,45 +96,74 @@ msgstr "Serveis del Firefox al núvol"
 msgid "Terms of Service"
 msgstr "Condicions del servei"
 
-#~ msgid "Are you sure?"
-#~ msgstr "Esteu segur?"
+#: templates/reset.html:2 templates/reset.txt:1
+msgid "Are you sure?"
+msgstr "Esteu segur?"
 
-#~ msgid "Please confirm that you'd like to reset the password for %(email)s."
-#~ msgstr "Confirmeu que voleu reiniciar la contrasenya de %(email)s"
+#: templates/reset.html:3 templates/reset.txt:2
+msgid "Please confirm that you'd like to reset the password for %(email)s."
+msgstr "Confirmeu que voleu reiniciar la contrasenya de %(email)s"
 
-#~ msgid "Reset password"
-#~ msgstr "Reinicia la contrasenya"
+#: templates/reset.html:4
+msgid "Reset password"
+msgstr "Reinicia la contrasenya"
 
-#~ msgid ""
-#~ "This is an automated email; if you received it in error, no action is "
-#~ "required."
-#~ msgstr "Aquest missatge és automàtic; no cal que feu res."
+#: templates/reset.html:5 templates/reset.txt:4 templates/unlock.html:4
+#: templates/unlock.txt:3 templates/verify.html:5 templates/verify.txt:4
+msgid ""
+"This is an automated email; if you received it in error, no action is "
+"required."
+msgstr "Aquest missatge és automàtic; no cal que feu res."
 
-#~ msgid ""
-#~ "For more information, please visit <a href='https://support.mozilla."
-#~ "org'>Mozilla Support</a>"
-#~ msgstr ""
-#~ "Per a més informació, visiteu l'<a href='https://support.mozilla."
-#~ "org'>ajuda de Mozilla</a>"
+#: templates/reset.html:6 templates/unlock.html:5 templates/verify.html:6
+msgid ""
+"For more information, please visit <a href='https://support.mozilla."
+"org'>Mozilla Support</a>"
+msgstr ""
+"Per a més informació, visiteu l'<a href='https://support.mozilla.org'>ajuda "
+"de Mozilla</a>"
 
-#~ msgid "Reset password:"
-#~ msgstr "Reinicia la contrasenya:"
+#: templates/reset.txt:3
+msgid "Reset password:"
+msgstr "Reinicia la contrasenya:"
 
-#~ msgid "For more information, please visit https://support.mozilla.org"
-#~ msgstr "Per a més informació, visiteu https://support.mozilla.org"
+#: templates/reset.txt:5 templates/unlock.txt:4 templates/verify.txt:5
+msgid "For more information, please visit https://support.mozilla.org"
+msgstr "Per a més informació, visiteu https://support.mozilla.org"
+
+#: templates/unlock.html:2 templates/unlock.txt:1
+msgid ""
+"For security reasons your Firefox Account was put on lockdown. To perform "
+"account-level activities, please click the link to re-verify your account "
+"now."
+msgstr ""
+
+#: templates/unlock.html:3
+msgid "Verify account"
+msgstr ""
+
+#: templates/unlock.txt:2
+msgid "Verify account:"
+msgstr ""
+
+#: templates/verify.html:2 templates/verify.txt:1
+msgid "Almost there"
+msgstr ""
+
+#: templates/verify.html:3 templates/verify.txt:2
+msgid "%(email)s, you're one click away from verifying your Firefox Account."
+msgstr "%(email)s, sou a punt de verificar el vostre compte del Firefox."
+
+#: templates/verify.html:4
+msgid "Verify"
+msgstr "Verifica"
+
+#: templates/verify.txt:3
+msgid "Verify:"
+msgstr "Verifica:"
 
 #~ msgid "Congratulations!"
 #~ msgstr "Felicitats!"
-
-#~ msgid ""
-#~ "%(email)s, you're one click away from verifying your Firefox Account."
-#~ msgstr "%(email)s, sou a punt de verificar el vostre compte del Firefox."
-
-#~ msgid "Verify"
-#~ msgstr "Verifica"
-
-#~ msgid "Verify:"
-#~ msgstr "Verifica:"
 
 #~ msgid "Verify your account"
 #~ msgstr "Verifiqueu el vostre compte"

--- a/locale/cs/LC_MESSAGES/server.po
+++ b/locale/cs/LC_MESSAGES/server.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-02-20 19:15+0000\n"
+"POT-Creation-Date: 2015-02-25 18:58+0000\n"
 "PO-Revision-Date: 2014-10-13 21:47+0000\n"
 "Last-Translator: Michal <michal.stanke@mikk.cz>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -19,7 +19,8 @@ msgstr ""
 #: server/templates/pages/src/503.html:1
 #: server/templates/pages/src/index.html:1
 #: server/templates/pages/src/privacy.html:1
-#: server/templates/pages/src/terms.html:1
+#: server/templates/pages/src/terms.html:1 templates/reset.html:1
+#: templates/unlock.html:1 templates/verify.html:1
 msgid "Firefox Accounts"
 msgstr "Firefox Accounts"
 
@@ -100,48 +101,76 @@ msgstr "Služby Firefox cloud"
 msgid "Terms of Service"
 msgstr "Podmínky využívání služby"
 
-#~ msgid "Are you sure?"
-#~ msgstr "Jste si jisti?"
+#: templates/reset.html:2 templates/reset.txt:1
+msgid "Are you sure?"
+msgstr "Jste si jisti?"
 
-#~ msgid "Please confirm that you'd like to reset the password for %(email)s."
-#~ msgstr "Potvrďte prosím obnovení hesla pro %(email)s ."
+#: templates/reset.html:3 templates/reset.txt:2
+msgid "Please confirm that you'd like to reset the password for %(email)s."
+msgstr "Potvrďte prosím obnovení hesla pro %(email)s ."
 
-#~ msgid "Reset password"
-#~ msgstr "Obnova hesla"
+#: templates/reset.html:4
+msgid "Reset password"
+msgstr "Obnova hesla"
 
-#~ msgid ""
-#~ "This is an automated email; if you received it in error, no action is "
-#~ "required."
-#~ msgstr ""
-#~ "Tento e-mail byl zaslán automaticky. Pokud jste si jej nevyžádali, můžete "
-#~ "jej ignorovat."
+#: templates/reset.html:5 templates/reset.txt:4 templates/unlock.html:4
+#: templates/unlock.txt:3 templates/verify.html:5 templates/verify.txt:4
+msgid ""
+"This is an automated email; if you received it in error, no action is "
+"required."
+msgstr ""
+"Tento e-mail byl zaslán automaticky. Pokud jste si jej nevyžádali, můžete "
+"jej ignorovat."
 
-#~ msgid ""
-#~ "For more information, please visit <a href='https://support.mozilla."
-#~ "org'>Mozilla Support</a>"
-#~ msgstr ""
-#~ "Pro více informací prosím navštivte <a href='https://support.mozilla."
-#~ "org'>Podporu Mozilly</a>"
+#: templates/reset.html:6 templates/unlock.html:5 templates/verify.html:6
+msgid ""
+"For more information, please visit <a href='https://support.mozilla."
+"org'>Mozilla Support</a>"
+msgstr ""
+"Pro více informací prosím navštivte <a href='https://support.mozilla."
+"org'>Podporu Mozilly</a>"
 
-#~ msgid "Reset password:"
-#~ msgstr "Obnovit heslo:"
+#: templates/reset.txt:3
+msgid "Reset password:"
+msgstr "Obnovit heslo:"
 
-#~ msgid "For more information, please visit https://support.mozilla.org"
-#~ msgstr "Pro více informací prosím navštivte https://support.mozilla.org"
+#: templates/reset.txt:5 templates/unlock.txt:4 templates/verify.txt:5
+msgid "For more information, please visit https://support.mozilla.org"
+msgstr "Pro více informací prosím navštivte https://support.mozilla.org"
+
+#: templates/unlock.html:2 templates/unlock.txt:1
+msgid ""
+"For security reasons your Firefox Account was put on lockdown. To perform "
+"account-level activities, please click the link to re-verify your account "
+"now."
+msgstr ""
+
+#: templates/unlock.html:3
+msgid "Verify account"
+msgstr ""
+
+#: templates/unlock.txt:2
+msgid "Verify account:"
+msgstr ""
+
+#: templates/verify.html:2 templates/verify.txt:1
+msgid "Almost there"
+msgstr ""
+
+#: templates/verify.html:3 templates/verify.txt:2
+msgid "%(email)s, you're one click away from verifying your Firefox Account."
+msgstr "%(email)s, již chybí jen kousek k ověření vašeho účtu Firefox Account."
+
+#: templates/verify.html:4
+msgid "Verify"
+msgstr "Ověřit"
+
+#: templates/verify.txt:3
+msgid "Verify:"
+msgstr "Ověřit:"
 
 #~ msgid "Congratulations!"
 #~ msgstr "Gratulujeme!"
-
-#~ msgid ""
-#~ "%(email)s, you're one click away from verifying your Firefox Account."
-#~ msgstr ""
-#~ "%(email)s, již chybí jen kousek k ověření vašeho účtu Firefox Account."
-
-#~ msgid "Verify"
-#~ msgstr "Ověřit"
-
-#~ msgid "Verify:"
-#~ msgstr "Ověřit:"
 
 #~ msgid "Verify your account"
 #~ msgstr "Ověřte svůj účet"

--- a/locale/cy/LC_MESSAGES/server.po
+++ b/locale/cy/LC_MESSAGES/server.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-02-20 19:15+0000\n"
+"POT-Creation-Date: 2015-02-25 18:58+0000\n"
 "PO-Revision-Date: 2015-02-26 14:42+0000\n"
 "Last-Translator: Rhoslyn <rprys@yahoo.com>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -20,7 +20,8 @@ msgstr ""
 #: server/templates/pages/src/503.html:1
 #: server/templates/pages/src/index.html:1
 #: server/templates/pages/src/privacy.html:1
-#: server/templates/pages/src/terms.html:1
+#: server/templates/pages/src/terms.html:1 templates/reset.html:1
+#: templates/unlock.html:1 templates/verify.html:1
 msgid "Firefox Accounts"
 msgstr "Cyfrifon Firefox"
 
@@ -80,9 +81,9 @@ msgid ""
 "You are using an <strong>outdated</strong> browser. Please <a href=\"http://"
 "browsehappy.com/\">upgrade your browser</a> to improve your experience."
 msgstr ""
-"Rydych y defnyddio <strong>hen</strong> borwr. Os gwelwch chi'n dda, <a "
-"href=\"http://browsehappy.com/\">diweddarwch eich porwr</a> er mwyn gwella "
-"eich profiad."
+"Rydych y defnyddio <strong>hen</strong> borwr. Os gwelwch chi'n dda, <a href="
+"\"http://browsehappy.com/\">diweddarwch eich porwr</a> er mwyn gwella eich "
+"profiad."
 
 #: server/templates/pages/src/index.html:3
 msgid "Firefox Accounts requires JavaScript."
@@ -103,47 +104,76 @@ msgstr "Gwasanaethau cwmwl Firefox"
 msgid "Terms of Service"
 msgstr "Amodau Gwasanaeth"
 
-#~ msgid "Are you sure?"
-#~ msgstr "Ydych chi'n siŵr?"
+#: templates/reset.html:2 templates/reset.txt:1
+msgid "Are you sure?"
+msgstr "Ydych chi'n siŵr?"
 
-#~ msgid "Please confirm that you'd like to reset the password for %(email)s."
-#~ msgstr "Cadarnhewch eich bod eisiau ailosod y cyfrinair ar gyfer %(email)s."
+#: templates/reset.html:3 templates/reset.txt:2
+msgid "Please confirm that you'd like to reset the password for %(email)s."
+msgstr "Cadarnhewch eich bod eisiau ailosod y cyfrinair ar gyfer %(email)s."
 
-#~ msgid "Reset password"
-#~ msgstr "Ailosod y cyfrinair"
+#: templates/reset.html:4
+msgid "Reset password"
+msgstr "Ailosod y cyfrinair"
 
-#~ msgid ""
-#~ "This is an automated email; if you received it in error, no action is "
-#~ "required."
-#~ msgstr ""
-#~ "E-bost awtomatig yw hwn; os ydych wedi derbyn yr e-bost hwn ar gam, nid "
-#~ "oes angen gweithredu."
+#: templates/reset.html:5 templates/reset.txt:4 templates/unlock.html:4
+#: templates/unlock.txt:3 templates/verify.html:5 templates/verify.txt:4
+msgid ""
+"This is an automated email; if you received it in error, no action is "
+"required."
+msgstr ""
+"E-bost awtomatig yw hwn; os ydych wedi derbyn yr e-bost hwn ar gam, nid oes "
+"angen gweithredu."
 
-#~ msgid ""
-#~ "For more information, please visit <a href='https://support.mozilla."
-#~ "org'>Mozilla Support</a>"
-#~ msgstr ""
-#~ "Am ragor o wybodaeth, ewch i <a href='https://support.mozilla."
-#~ "org'>Mozilla Support</a>"
+#: templates/reset.html:6 templates/unlock.html:5 templates/verify.html:6
+msgid ""
+"For more information, please visit <a href='https://support.mozilla."
+"org'>Mozilla Support</a>"
+msgstr ""
+"Am ragor o wybodaeth, ewch i <a href='https://support.mozilla.org'>Mozilla "
+"Support</a>"
 
-#~ msgid "Reset password:"
-#~ msgstr "Ailsod y cyfrinair:"
+#: templates/reset.txt:3
+msgid "Reset password:"
+msgstr "Ailsod y cyfrinair:"
 
-#~ msgid "For more information, please visit https://support.mozilla.org"
-#~ msgstr "Am ragor o wybodaeth, ewch i https://support.mozilla.org"
+#: templates/reset.txt:5 templates/unlock.txt:4 templates/verify.txt:5
+msgid "For more information, please visit https://support.mozilla.org"
+msgstr "Am ragor o wybodaeth, ewch i https://support.mozilla.org"
+
+#: templates/unlock.html:2 templates/unlock.txt:1
+msgid ""
+"For security reasons your Firefox Account was put on lockdown. To perform "
+"account-level activities, please click the link to re-verify your account "
+"now."
+msgstr ""
+
+#: templates/unlock.html:3
+msgid "Verify account"
+msgstr ""
+
+#: templates/unlock.txt:2
+msgid "Verify account:"
+msgstr ""
+
+#: templates/verify.html:2 templates/verify.txt:1
+msgid "Almost there"
+msgstr ""
+
+#: templates/verify.html:3 templates/verify.txt:2
+msgid "%(email)s, you're one click away from verifying your Firefox Account."
+msgstr "%(email)s, rydych eiliadau i ffwrdd o ddilysu eich Cyfrif Firefox."
+
+#: templates/verify.html:4
+msgid "Verify"
+msgstr "Dilysu"
+
+#: templates/verify.txt:3
+msgid "Verify:"
+msgstr "Dilysu:"
 
 #~ msgid "Congratulations!"
 #~ msgstr "Llongyfarchiadau!"
-
-#~ msgid ""
-#~ "%(email)s, you're one click away from verifying your Firefox Account."
-#~ msgstr "%(email)s, rydych eiliadau i ffwrdd o ddilysu eich Cyfrif Firefox."
-
-#~ msgid "Verify"
-#~ msgstr "Dilysu"
-
-#~ msgid "Verify:"
-#~ msgstr "Dilysu:"
 
 #~ msgid "Verify your account"
 #~ msgstr "Cadarnhau eich cyfrif"

--- a/locale/da/LC_MESSAGES/server.po
+++ b/locale/da/LC_MESSAGES/server.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-02-20 19:15+0000\n"
+"POT-Creation-Date: 2015-02-25 18:58+0000\n"
 "PO-Revision-Date: 2014-10-26 18:50+0000\n"
 "Last-Translator: Jørgen   <joergenr@stofanet.dk>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -19,7 +19,8 @@ msgstr ""
 #: server/templates/pages/src/503.html:1
 #: server/templates/pages/src/index.html:1
 #: server/templates/pages/src/privacy.html:1
-#: server/templates/pages/src/terms.html:1
+#: server/templates/pages/src/terms.html:1 templates/reset.html:1
+#: templates/unlock.html:1 templates/verify.html:1
 msgid "Firefox Accounts"
 msgstr "Firefox-konti"
 
@@ -101,47 +102,76 @@ msgstr "Firefox online-tjenester"
 msgid "Terms of Service"
 msgstr "Tjenestevilkår"
 
-#~ msgid "Are you sure?"
-#~ msgstr "Er du sikker?"
+#: templates/reset.html:2 templates/reset.txt:1
+msgid "Are you sure?"
+msgstr "Er du sikker?"
 
-#~ msgid "Please confirm that you'd like to reset the password for %(email)s."
-#~ msgstr "Bekræft, at du vil nulstille adgangskoden til %(email)s."
+#: templates/reset.html:3 templates/reset.txt:2
+msgid "Please confirm that you'd like to reset the password for %(email)s."
+msgstr "Bekræft, at du vil nulstille adgangskoden til %(email)s."
 
-#~ msgid "Reset password"
-#~ msgstr "Nulstil adgangskode"
+#: templates/reset.html:4
+msgid "Reset password"
+msgstr "Nulstil adgangskode"
 
-#~ msgid ""
-#~ "This is an automated email; if you received it in error, no action is "
-#~ "required."
-#~ msgstr ""
-#~ "Dette er en automatiseret mail; hvis du har modtaget denne mail ved en "
-#~ "fejl, behøver du ikke foretage dig noget."
+#: templates/reset.html:5 templates/reset.txt:4 templates/unlock.html:4
+#: templates/unlock.txt:3 templates/verify.html:5 templates/verify.txt:4
+msgid ""
+"This is an automated email; if you received it in error, no action is "
+"required."
+msgstr ""
+"Dette er en automatiseret mail; hvis du har modtaget denne mail ved en fejl, "
+"behøver du ikke foretage dig noget."
 
-#~ msgid ""
-#~ "For more information, please visit <a href='https://support.mozilla."
-#~ "org'>Mozilla Support</a>"
-#~ msgstr ""
-#~ "For yderligere information, besøg <a href='https://support.mozilla."
-#~ "org'>Mozilla Support</a>"
+#: templates/reset.html:6 templates/unlock.html:5 templates/verify.html:6
+msgid ""
+"For more information, please visit <a href='https://support.mozilla."
+"org'>Mozilla Support</a>"
+msgstr ""
+"For yderligere information, besøg <a href='https://support.mozilla."
+"org'>Mozilla Support</a>"
 
-#~ msgid "Reset password:"
-#~ msgstr "Nulstil adgangskode:"
+#: templates/reset.txt:3
+msgid "Reset password:"
+msgstr "Nulstil adgangskode:"
 
-#~ msgid "For more information, please visit https://support.mozilla.org"
-#~ msgstr "For mere information, besøg https://support.mozilla.org"
+#: templates/reset.txt:5 templates/unlock.txt:4 templates/verify.txt:5
+msgid "For more information, please visit https://support.mozilla.org"
+msgstr "For mere information, besøg https://support.mozilla.org"
+
+#: templates/unlock.html:2 templates/unlock.txt:1
+msgid ""
+"For security reasons your Firefox Account was put on lockdown. To perform "
+"account-level activities, please click the link to re-verify your account "
+"now."
+msgstr ""
+
+#: templates/unlock.html:3
+msgid "Verify account"
+msgstr ""
+
+#: templates/unlock.txt:2
+msgid "Verify account:"
+msgstr ""
+
+#: templates/verify.html:2 templates/verify.txt:1
+msgid "Almost there"
+msgstr ""
+
+#: templates/verify.html:3 templates/verify.txt:2
+msgid "%(email)s, you're one click away from verifying your Firefox Account."
+msgstr "%(email)s, du er et klik fra at bekræfte din Firefox-konto."
+
+#: templates/verify.html:4
+msgid "Verify"
+msgstr "Bekræft"
+
+#: templates/verify.txt:3
+msgid "Verify:"
+msgstr "Bekræft:"
 
 #~ msgid "Congratulations!"
 #~ msgstr "Tillykke!"
-
-#~ msgid ""
-#~ "%(email)s, you're one click away from verifying your Firefox Account."
-#~ msgstr "%(email)s, du er et klik fra at bekræfte din Firefox-konto."
-
-#~ msgid "Verify"
-#~ msgstr "Bekræft"
-
-#~ msgid "Verify:"
-#~ msgstr "Bekræft:"
 
 #~ msgid "Verify your account"
 #~ msgstr "Bekræft din konto"

--- a/locale/de/LC_MESSAGES/server.po
+++ b/locale/de/LC_MESSAGES/server.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-02-20 19:15+0000\n"
+"POT-Creation-Date: 2015-02-25 18:58+0000\n"
 "PO-Revision-Date: 2015-02-21 09:15+0000\n"
 "Last-Translator: Michael <michael.koehler1@gmx.de>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -19,7 +19,8 @@ msgstr ""
 #: server/templates/pages/src/503.html:1
 #: server/templates/pages/src/index.html:1
 #: server/templates/pages/src/privacy.html:1
-#: server/templates/pages/src/terms.html:1
+#: server/templates/pages/src/terms.html:1 templates/reset.html:1
+#: templates/unlock.html:1 templates/verify.html:1
 msgid "Firefox Accounts"
 msgstr "Firefox-Konten"
 
@@ -102,51 +103,80 @@ msgstr "Firefox-Online-Dienste"
 msgid "Terms of Service"
 msgstr "Nutzungsbedingungen"
 
-#~ msgid "Are you sure?"
-#~ msgstr "Sind Sie sicher?"
+#: templates/reset.html:2 templates/reset.txt:1
+msgid "Are you sure?"
+msgstr "Sind Sie sicher?"
 
-#~ msgid "Please confirm that you'd like to reset the password for %(email)s."
-#~ msgstr ""
-#~ "Bitte bestätigen Sie, dass Sie das Passwort für %(email)s zurücksetzen "
-#~ "möchten."
+#: templates/reset.html:3 templates/reset.txt:2
+msgid "Please confirm that you'd like to reset the password for %(email)s."
+msgstr ""
+"Bitte bestätigen Sie, dass Sie das Passwort für %(email)s zurücksetzen "
+"möchten."
 
-#~ msgid "Reset password"
-#~ msgstr "Passwort zurücksetzen"
+#: templates/reset.html:4
+msgid "Reset password"
+msgstr "Passwort zurücksetzen"
 
-#~ msgid ""
-#~ "This is an automated email; if you received it in error, no action is "
-#~ "required."
-#~ msgstr ""
-#~ "Dies ist eine automatisierte E-Mail; wenn Sie sie fälschlicherweise "
-#~ "erhalten haben, müssen Sie nichts tun."
+#: templates/reset.html:5 templates/reset.txt:4 templates/unlock.html:4
+#: templates/unlock.txt:3 templates/verify.html:5 templates/verify.txt:4
+msgid ""
+"This is an automated email; if you received it in error, no action is "
+"required."
+msgstr ""
+"Dies ist eine automatisierte E-Mail; wenn Sie sie fälschlicherweise erhalten "
+"haben, müssen Sie nichts tun."
 
-#~ msgid ""
-#~ "For more information, please visit <a href='https://support.mozilla."
-#~ "org'>Mozilla Support</a>"
-#~ msgstr ""
-#~ "Weitere Informationen finden Sie in der <a href='https://support.mozilla."
-#~ "org'>Mozilla-Hilfe</a>"
+#: templates/reset.html:6 templates/unlock.html:5 templates/verify.html:6
+msgid ""
+"For more information, please visit <a href='https://support.mozilla."
+"org'>Mozilla Support</a>"
+msgstr ""
+"Weitere Informationen finden Sie in der <a href='https://support.mozilla."
+"org'>Mozilla-Hilfe</a>"
 
-#~ msgid "Reset password:"
-#~ msgstr "Passwort zurücksetzen:"
+#: templates/reset.txt:3
+msgid "Reset password:"
+msgstr "Passwort zurücksetzen:"
 
-#~ msgid "For more information, please visit https://support.mozilla.org"
-#~ msgstr "Weitere Informationen finden Sie unter https://support.mozilla.org"
+#: templates/reset.txt:5 templates/unlock.txt:4 templates/verify.txt:5
+msgid "For more information, please visit https://support.mozilla.org"
+msgstr "Weitere Informationen finden Sie unter https://support.mozilla.org"
+
+#: templates/unlock.html:2 templates/unlock.txt:1
+msgid ""
+"For security reasons your Firefox Account was put on lockdown. To perform "
+"account-level activities, please click the link to re-verify your account "
+"now."
+msgstr ""
+
+#: templates/unlock.html:3
+msgid "Verify account"
+msgstr ""
+
+#: templates/unlock.txt:2
+msgid "Verify account:"
+msgstr ""
+
+#: templates/verify.html:2 templates/verify.txt:1
+msgid "Almost there"
+msgstr ""
+
+#: templates/verify.html:3 templates/verify.txt:2
+msgid "%(email)s, you're one click away from verifying your Firefox Account."
+msgstr ""
+"%(email)s, Sie sind nur noch Sekunden von der Verifizierung Ihres Firefox-"
+"Kontos entfernt."
+
+#: templates/verify.html:4
+msgid "Verify"
+msgstr "Bestätigen"
+
+#: templates/verify.txt:3
+msgid "Verify:"
+msgstr "Bestätigen:"
 
 #~ msgid "Congratulations!"
 #~ msgstr "Herzlichen Glückwunsch!"
-
-#~ msgid ""
-#~ "%(email)s, you're one click away from verifying your Firefox Account."
-#~ msgstr ""
-#~ "%(email)s, Sie sind nur noch Sekunden von der Verifizierung Ihres Firefox-"
-#~ "Kontos entfernt."
-
-#~ msgid "Verify"
-#~ msgstr "Bestätigen"
-
-#~ msgid "Verify:"
-#~ msgstr "Bestätigen:"
 
 #~ msgid "Verify your account"
 #~ msgstr "Bestätigen Sie Ihr Konto"

--- a/locale/dsb/LC_MESSAGES/server.po
+++ b/locale/dsb/LC_MESSAGES/server.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2014-11-10 18:39+0000\n"
+"POT-Creation-Date: 2015-02-25 18:58+0000\n"
 "PO-Revision-Date: 2015-01-08 19:45+0000\n"
 "Last-Translator: milupo <milupo@sorbzilla.de>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -10,19 +10,24 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=4; plural=(n%100==1 ? 0 : n%100==2 ? 1 : n%100==3 || "
-"n%100==4 ? 2 : 3);\n"
+"Plural-Forms: nplurals=4; plural=(n%100==1 ? 0 : n%100==2 ? 1 : n%100==3 || n"
+"%100==4 ? 2 : 3);\n"
 "X-Generator: Pootle 2.5.0\n"
 "X-POOTLE-MTIME: 1420746356.0\n"
 
-#: server/templates/pages/src/404.html:1 server/templates/pages/src/500.html:1
+#: server/templates/pages/src/400.html:1 server/templates/pages/src/404.html:1
+#: server/templates/pages/src/500.html:1 server/templates/pages/src/502.html:1
 #: server/templates/pages/src/503.html:1
 #: server/templates/pages/src/index.html:1
 #: server/templates/pages/src/privacy.html:1
-#: server/templates/pages/src/terms.html:1 server/templates/email/reset.html:1
-#: server/templates/email/verify.html:1
+#: server/templates/pages/src/terms.html:1 templates/reset.html:1
+#: templates/unlock.html:1 templates/verify.html:1
 msgid "Firefox Accounts"
 msgstr "Konta Firefox"
+
+#: server/templates/pages/src/400.html:2
+msgid "Bad Request"
+msgstr ""
 
 #: server/templates/pages/src/404.html:2
 msgid "Page not found"
@@ -37,7 +42,7 @@ msgstr ""
 "njepłaśiwe wótkaze."
 
 #: server/templates/pages/src/404.html:4 server/templates/pages/src/500.html:4
-#: server/templates/pages/src/503.html:4
+#: server/templates/pages/src/502.html:4 server/templates/pages/src/503.html:4
 msgid "Home"
 msgstr "Startowy bok"
 
@@ -45,13 +50,17 @@ msgstr "Startowy bok"
 msgid "500 Error"
 msgstr "Zmólka 500"
 
-#: server/templates/pages/src/500.html:3
+#: server/templates/pages/src/500.html:3 server/templates/pages/src/502.html:3
 msgid ""
 "Oh dear, something went wrong there. We've been notified and will get "
 "working on a fix."
 msgstr ""
 "Mój Bog, něco jo kśiwje šło. Smy se informěrowali a dajomy se do "
 "wótwónoźowanja problema."
+
+#: server/templates/pages/src/502.html:2
+msgid "502 Error"
+msgstr ""
 
 #: server/templates/pages/src/503.html:2
 msgid "Server busy, try again soon"
@@ -95,20 +104,20 @@ msgstr "Mrokowsłužby Firefox"
 msgid "Terms of Service"
 msgstr "Wužywańske wuměnenja"
 
-#: server/templates/email/reset.html:2 server/templates/email/reset.txt:1
+#: templates/reset.html:2 templates/reset.txt:1
 msgid "Are you sure?"
 msgstr "Sćo se wěsty?"
 
-#: server/templates/email/reset.html:3 server/templates/email/reset.txt:2
+#: templates/reset.html:3 templates/reset.txt:2
 msgid "Please confirm that you'd like to reset the password for %(email)s."
 msgstr "Pšosym wobkšuśćo, až cośo gronidło za %(email)s slědk stajiś."
 
-#: server/templates/email/reset.html:4
+#: templates/reset.html:4
 msgid "Reset password"
 msgstr "Gronidło slědk stajiś"
 
-#: server/templates/email/reset.html:5 server/templates/email/reset.txt:4
-#: server/templates/email/verify.html:5 server/templates/email/verify.txt:4
+#: templates/reset.html:5 templates/reset.txt:4 templates/unlock.html:4
+#: templates/unlock.txt:3 templates/verify.html:5 templates/verify.txt:4
 msgid ""
 "This is an automated email; if you received it in error, no action is "
 "required."
@@ -116,7 +125,7 @@ msgstr ""
 "To jo awtomatizěrowana mailka; joli sćo ju zamólnje dostał, njetrjebaśo nic "
 "cyniś."
 
-#: server/templates/email/reset.html:6 server/templates/email/verify.html:6
+#: templates/reset.html:6 templates/unlock.html:5 templates/verify.html:6
 msgid ""
 "For more information, please visit <a href='https://support.mozilla."
 "org'>Mozilla Support</a>"
@@ -124,39 +133,55 @@ msgstr ""
 "Za dalšne informacije woglědajśo se pšosym <a href='https://support.mozilla."
 "org'>pomoc Mozilla</a>"
 
-#: server/templates/email/reset.txt:3
+#: templates/reset.txt:3
 msgid "Reset password:"
 msgstr "Gronidło slědk stajiś:"
 
-#: server/templates/email/reset.txt:5 server/templates/email/verify.txt:5
+#: templates/reset.txt:5 templates/unlock.txt:4 templates/verify.txt:5
 msgid "For more information, please visit https://support.mozilla.org"
 msgstr "Za dalšne informacije woglědajśo se pšosym https://support.mozilla.org"
 
-#: server/templates/email/verify.html:2 server/templates/email/verify.txt:1
-msgid "Congratulations!"
-msgstr "Glukužycenje!"
+#: templates/unlock.html:2 templates/unlock.txt:1
+msgid ""
+"For security reasons your Firefox Account was put on lockdown. To perform "
+"account-level activities, please click the link to re-verify your account "
+"now."
+msgstr ""
 
-#: server/templates/email/verify.html:3 server/templates/email/verify.txt:2
+#: templates/unlock.html:3
+msgid "Verify account"
+msgstr ""
+
+#: templates/unlock.txt:2
+msgid "Verify account:"
+msgstr ""
+
+#: templates/verify.html:2 templates/verify.txt:1
+msgid "Almost there"
+msgstr ""
+
+#: templates/verify.html:3 templates/verify.txt:2
 msgid "%(email)s, you're one click away from verifying your Firefox Account."
 msgstr ""
 "%(email)s, sćo jano jadno kliknjenje wót wobkšuśenja swójogo konta Firefox "
 "zdalony."
 
-#: server/templates/email/verify.html:4
+#: templates/verify.html:4
 msgid "Verify"
 msgstr "Wobkšuśiś"
 
-#: server/templates/email/verify.txt:3
+#: templates/verify.txt:3
 msgid "Verify:"
 msgstr "Wobkšuśiś:"
 
-#: server/lib/templates.js:63
-msgid "Verify your account"
-msgstr "Wobkšuśćo swójo konto"
+#~ msgid "Congratulations!"
+#~ msgstr "Glukužycenje!"
 
-#: server/lib/templates.js:68
-msgid "Reset your password"
-msgstr "Stajśo swójo gronidło slědk"
+#~ msgid "Verify your account"
+#~ msgstr "Wobkšuśćo swójo konto"
+
+#~ msgid "Reset your password"
+#~ msgstr "Stajśo swójo gronidło slědk"
 
 #~ msgid "System unavailable, try again soon"
 #~ msgstr "System njestoj k dispoziciji, wopytajśo za krotki cas hyšći raz"

--- a/locale/el/LC_MESSAGES/server.po
+++ b/locale/el/LC_MESSAGES/server.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-02-20 19:15+0000\n"
+"POT-Creation-Date: 2015-02-25 18:58+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "Language: \n"
@@ -15,7 +15,8 @@ msgstr ""
 #: server/templates/pages/src/503.html:1
 #: server/templates/pages/src/index.html:1
 #: server/templates/pages/src/privacy.html:1
-#: server/templates/pages/src/terms.html:1
+#: server/templates/pages/src/terms.html:1 templates/reset.html:1
+#: templates/unlock.html:1 templates/verify.html:1
 msgid "Firefox Accounts"
 msgstr ""
 
@@ -87,4 +88,68 @@ msgstr ""
 #: server/templates/pages/src/terms.html:2
 #: server/templates/pages/src/terms.html:5
 msgid "Terms of Service"
+msgstr ""
+
+#: templates/reset.html:2 templates/reset.txt:1
+msgid "Are you sure?"
+msgstr ""
+
+#: templates/reset.html:3 templates/reset.txt:2
+msgid "Please confirm that you'd like to reset the password for %(email)s."
+msgstr ""
+
+#: templates/reset.html:4
+msgid "Reset password"
+msgstr ""
+
+#: templates/reset.html:5 templates/reset.txt:4 templates/unlock.html:4
+#: templates/unlock.txt:3 templates/verify.html:5 templates/verify.txt:4
+msgid ""
+"This is an automated email; if you received it in error, no action is "
+"required."
+msgstr ""
+
+#: templates/reset.html:6 templates/unlock.html:5 templates/verify.html:6
+msgid ""
+"For more information, please visit <a href='https://support.mozilla."
+"org'>Mozilla Support</a>"
+msgstr ""
+
+#: templates/reset.txt:3
+msgid "Reset password:"
+msgstr ""
+
+#: templates/reset.txt:5 templates/unlock.txt:4 templates/verify.txt:5
+msgid "For more information, please visit https://support.mozilla.org"
+msgstr ""
+
+#: templates/unlock.html:2 templates/unlock.txt:1
+msgid ""
+"For security reasons your Firefox Account was put on lockdown. To perform "
+"account-level activities, please click the link to re-verify your account "
+"now."
+msgstr ""
+
+#: templates/unlock.html:3
+msgid "Verify account"
+msgstr ""
+
+#: templates/unlock.txt:2
+msgid "Verify account:"
+msgstr ""
+
+#: templates/verify.html:2 templates/verify.txt:1
+msgid "Almost there"
+msgstr ""
+
+#: templates/verify.html:3 templates/verify.txt:2
+msgid "%(email)s, you're one click away from verifying your Firefox Account."
+msgstr ""
+
+#: templates/verify.html:4
+msgid "Verify"
+msgstr ""
+
+#: templates/verify.txt:3
+msgid "Verify:"
 msgstr ""

--- a/locale/en/LC_MESSAGES/server.po
+++ b/locale/en/LC_MESSAGES/server.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-02-20 19:15+0000\n"
+"POT-Creation-Date: 2015-02-25 18:58+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,7 +17,8 @@ msgstr ""
 #: server/templates/pages/src/503.html:1
 #: server/templates/pages/src/index.html:1
 #: server/templates/pages/src/privacy.html:1
-#: server/templates/pages/src/terms.html:1
+#: server/templates/pages/src/terms.html:1 templates/reset.html:1
+#: templates/unlock.html:1 templates/verify.html:1
 msgid "Firefox Accounts"
 msgstr ""
 
@@ -89,4 +90,68 @@ msgstr ""
 #: server/templates/pages/src/terms.html:2
 #: server/templates/pages/src/terms.html:5
 msgid "Terms of Service"
+msgstr ""
+
+#: templates/reset.html:2 templates/reset.txt:1
+msgid "Are you sure?"
+msgstr ""
+
+#: templates/reset.html:3 templates/reset.txt:2
+msgid "Please confirm that you'd like to reset the password for %(email)s."
+msgstr ""
+
+#: templates/reset.html:4
+msgid "Reset password"
+msgstr ""
+
+#: templates/reset.html:5 templates/reset.txt:4 templates/unlock.html:4
+#: templates/unlock.txt:3 templates/verify.html:5 templates/verify.txt:4
+msgid ""
+"This is an automated email; if you received it in error, no action is "
+"required."
+msgstr ""
+
+#: templates/reset.html:6 templates/unlock.html:5 templates/verify.html:6
+msgid ""
+"For more information, please visit <a href='https://support.mozilla."
+"org'>Mozilla Support</a>"
+msgstr ""
+
+#: templates/reset.txt:3
+msgid "Reset password:"
+msgstr ""
+
+#: templates/reset.txt:5 templates/unlock.txt:4 templates/verify.txt:5
+msgid "For more information, please visit https://support.mozilla.org"
+msgstr ""
+
+#: templates/unlock.html:2 templates/unlock.txt:1
+msgid ""
+"For security reasons your Firefox Account was put on lockdown. To perform "
+"account-level activities, please click the link to re-verify your account "
+"now."
+msgstr ""
+
+#: templates/unlock.html:3
+msgid "Verify account"
+msgstr ""
+
+#: templates/unlock.txt:2
+msgid "Verify account:"
+msgstr ""
+
+#: templates/verify.html:2 templates/verify.txt:1
+msgid "Almost there"
+msgstr ""
+
+#: templates/verify.html:3 templates/verify.txt:2
+msgid "%(email)s, you're one click away from verifying your Firefox Account."
+msgstr ""
+
+#: templates/verify.html:4
+msgid "Verify"
+msgstr ""
+
+#: templates/verify.txt:3
+msgid "Verify:"
 msgstr ""

--- a/locale/en_GB/LC_MESSAGES/server.po
+++ b/locale/en_GB/LC_MESSAGES/server.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-02-20 19:15+0000\n"
+"POT-Creation-Date: 2015-02-25 18:58+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,7 +17,8 @@ msgstr ""
 #: server/templates/pages/src/503.html:1
 #: server/templates/pages/src/index.html:1
 #: server/templates/pages/src/privacy.html:1
-#: server/templates/pages/src/terms.html:1
+#: server/templates/pages/src/terms.html:1 templates/reset.html:1
+#: templates/unlock.html:1 templates/verify.html:1
 msgid "Firefox Accounts"
 msgstr ""
 
@@ -89,4 +90,68 @@ msgstr ""
 #: server/templates/pages/src/terms.html:2
 #: server/templates/pages/src/terms.html:5
 msgid "Terms of Service"
+msgstr ""
+
+#: templates/reset.html:2 templates/reset.txt:1
+msgid "Are you sure?"
+msgstr ""
+
+#: templates/reset.html:3 templates/reset.txt:2
+msgid "Please confirm that you'd like to reset the password for %(email)s."
+msgstr ""
+
+#: templates/reset.html:4
+msgid "Reset password"
+msgstr ""
+
+#: templates/reset.html:5 templates/reset.txt:4 templates/unlock.html:4
+#: templates/unlock.txt:3 templates/verify.html:5 templates/verify.txt:4
+msgid ""
+"This is an automated email; if you received it in error, no action is "
+"required."
+msgstr ""
+
+#: templates/reset.html:6 templates/unlock.html:5 templates/verify.html:6
+msgid ""
+"For more information, please visit <a href='https://support.mozilla."
+"org'>Mozilla Support</a>"
+msgstr ""
+
+#: templates/reset.txt:3
+msgid "Reset password:"
+msgstr ""
+
+#: templates/reset.txt:5 templates/unlock.txt:4 templates/verify.txt:5
+msgid "For more information, please visit https://support.mozilla.org"
+msgstr ""
+
+#: templates/unlock.html:2 templates/unlock.txt:1
+msgid ""
+"For security reasons your Firefox Account was put on lockdown. To perform "
+"account-level activities, please click the link to re-verify your account "
+"now."
+msgstr ""
+
+#: templates/unlock.html:3
+msgid "Verify account"
+msgstr ""
+
+#: templates/unlock.txt:2
+msgid "Verify account:"
+msgstr ""
+
+#: templates/verify.html:2 templates/verify.txt:1
+msgid "Almost there"
+msgstr ""
+
+#: templates/verify.html:3 templates/verify.txt:2
+msgid "%(email)s, you're one click away from verifying your Firefox Account."
+msgstr ""
+
+#: templates/verify.html:4
+msgid "Verify"
+msgstr ""
+
+#: templates/verify.txt:3
+msgid "Verify:"
 msgstr ""

--- a/locale/en_US/LC_MESSAGES/server.po
+++ b/locale/en_US/LC_MESSAGES/server.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-02-20 19:15+0000\n"
+"POT-Creation-Date: 2015-02-25 18:58+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "Language: en_US\n"
@@ -15,7 +15,8 @@ msgstr ""
 #: server/templates/pages/src/503.html:1
 #: server/templates/pages/src/index.html:1
 #: server/templates/pages/src/privacy.html:1
-#: server/templates/pages/src/terms.html:1
+#: server/templates/pages/src/terms.html:1 templates/reset.html:1
+#: templates/unlock.html:1 templates/verify.html:1
 msgid "Firefox Accounts"
 msgstr ""
 
@@ -87,4 +88,68 @@ msgstr ""
 #: server/templates/pages/src/terms.html:2
 #: server/templates/pages/src/terms.html:5
 msgid "Terms of Service"
+msgstr ""
+
+#: templates/reset.html:2 templates/reset.txt:1
+msgid "Are you sure?"
+msgstr ""
+
+#: templates/reset.html:3 templates/reset.txt:2
+msgid "Please confirm that you'd like to reset the password for %(email)s."
+msgstr ""
+
+#: templates/reset.html:4
+msgid "Reset password"
+msgstr ""
+
+#: templates/reset.html:5 templates/reset.txt:4 templates/unlock.html:4
+#: templates/unlock.txt:3 templates/verify.html:5 templates/verify.txt:4
+msgid ""
+"This is an automated email; if you received it in error, no action is "
+"required."
+msgstr ""
+
+#: templates/reset.html:6 templates/unlock.html:5 templates/verify.html:6
+msgid ""
+"For more information, please visit <a href='https://support.mozilla."
+"org'>Mozilla Support</a>"
+msgstr ""
+
+#: templates/reset.txt:3
+msgid "Reset password:"
+msgstr ""
+
+#: templates/reset.txt:5 templates/unlock.txt:4 templates/verify.txt:5
+msgid "For more information, please visit https://support.mozilla.org"
+msgstr ""
+
+#: templates/unlock.html:2 templates/unlock.txt:1
+msgid ""
+"For security reasons your Firefox Account was put on lockdown. To perform "
+"account-level activities, please click the link to re-verify your account "
+"now."
+msgstr ""
+
+#: templates/unlock.html:3
+msgid "Verify account"
+msgstr ""
+
+#: templates/unlock.txt:2
+msgid "Verify account:"
+msgstr ""
+
+#: templates/verify.html:2 templates/verify.txt:1
+msgid "Almost there"
+msgstr ""
+
+#: templates/verify.html:3 templates/verify.txt:2
+msgid "%(email)s, you're one click away from verifying your Firefox Account."
+msgstr ""
+
+#: templates/verify.html:4
+msgid "Verify"
+msgstr ""
+
+#: templates/verify.txt:3
+msgid "Verify:"
 msgstr ""

--- a/locale/en_ZA/LC_MESSAGES/server.po
+++ b/locale/en_ZA/LC_MESSAGES/server.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-02-20 19:15+0000\n"
+"POT-Creation-Date: 2015-02-25 18:58+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,7 +17,8 @@ msgstr ""
 #: server/templates/pages/src/503.html:1
 #: server/templates/pages/src/index.html:1
 #: server/templates/pages/src/privacy.html:1
-#: server/templates/pages/src/terms.html:1
+#: server/templates/pages/src/terms.html:1 templates/reset.html:1
+#: templates/unlock.html:1 templates/verify.html:1
 msgid "Firefox Accounts"
 msgstr ""
 
@@ -89,4 +90,68 @@ msgstr ""
 #: server/templates/pages/src/terms.html:2
 #: server/templates/pages/src/terms.html:5
 msgid "Terms of Service"
+msgstr ""
+
+#: templates/reset.html:2 templates/reset.txt:1
+msgid "Are you sure?"
+msgstr ""
+
+#: templates/reset.html:3 templates/reset.txt:2
+msgid "Please confirm that you'd like to reset the password for %(email)s."
+msgstr ""
+
+#: templates/reset.html:4
+msgid "Reset password"
+msgstr ""
+
+#: templates/reset.html:5 templates/reset.txt:4 templates/unlock.html:4
+#: templates/unlock.txt:3 templates/verify.html:5 templates/verify.txt:4
+msgid ""
+"This is an automated email; if you received it in error, no action is "
+"required."
+msgstr ""
+
+#: templates/reset.html:6 templates/unlock.html:5 templates/verify.html:6
+msgid ""
+"For more information, please visit <a href='https://support.mozilla."
+"org'>Mozilla Support</a>"
+msgstr ""
+
+#: templates/reset.txt:3
+msgid "Reset password:"
+msgstr ""
+
+#: templates/reset.txt:5 templates/unlock.txt:4 templates/verify.txt:5
+msgid "For more information, please visit https://support.mozilla.org"
+msgstr ""
+
+#: templates/unlock.html:2 templates/unlock.txt:1
+msgid ""
+"For security reasons your Firefox Account was put on lockdown. To perform "
+"account-level activities, please click the link to re-verify your account "
+"now."
+msgstr ""
+
+#: templates/unlock.html:3
+msgid "Verify account"
+msgstr ""
+
+#: templates/unlock.txt:2
+msgid "Verify account:"
+msgstr ""
+
+#: templates/verify.html:2 templates/verify.txt:1
+msgid "Almost there"
+msgstr ""
+
+#: templates/verify.html:3 templates/verify.txt:2
+msgid "%(email)s, you're one click away from verifying your Firefox Account."
+msgstr ""
+
+#: templates/verify.html:4
+msgid "Verify"
+msgstr ""
+
+#: templates/verify.txt:3
+msgid "Verify:"
 msgstr ""

--- a/locale/eo/LC_MESSAGES/server.po
+++ b/locale/eo/LC_MESSAGES/server.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-02-20 19:15+0000\n"
+"POT-Creation-Date: 2015-02-25 18:58+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "Language: \n"
@@ -15,7 +15,8 @@ msgstr ""
 #: server/templates/pages/src/503.html:1
 #: server/templates/pages/src/index.html:1
 #: server/templates/pages/src/privacy.html:1
-#: server/templates/pages/src/terms.html:1
+#: server/templates/pages/src/terms.html:1 templates/reset.html:1
+#: templates/unlock.html:1 templates/verify.html:1
 msgid "Firefox Accounts"
 msgstr ""
 
@@ -87,4 +88,68 @@ msgstr ""
 #: server/templates/pages/src/terms.html:2
 #: server/templates/pages/src/terms.html:5
 msgid "Terms of Service"
+msgstr ""
+
+#: templates/reset.html:2 templates/reset.txt:1
+msgid "Are you sure?"
+msgstr ""
+
+#: templates/reset.html:3 templates/reset.txt:2
+msgid "Please confirm that you'd like to reset the password for %(email)s."
+msgstr ""
+
+#: templates/reset.html:4
+msgid "Reset password"
+msgstr ""
+
+#: templates/reset.html:5 templates/reset.txt:4 templates/unlock.html:4
+#: templates/unlock.txt:3 templates/verify.html:5 templates/verify.txt:4
+msgid ""
+"This is an automated email; if you received it in error, no action is "
+"required."
+msgstr ""
+
+#: templates/reset.html:6 templates/unlock.html:5 templates/verify.html:6
+msgid ""
+"For more information, please visit <a href='https://support.mozilla."
+"org'>Mozilla Support</a>"
+msgstr ""
+
+#: templates/reset.txt:3
+msgid "Reset password:"
+msgstr ""
+
+#: templates/reset.txt:5 templates/unlock.txt:4 templates/verify.txt:5
+msgid "For more information, please visit https://support.mozilla.org"
+msgstr ""
+
+#: templates/unlock.html:2 templates/unlock.txt:1
+msgid ""
+"For security reasons your Firefox Account was put on lockdown. To perform "
+"account-level activities, please click the link to re-verify your account "
+"now."
+msgstr ""
+
+#: templates/unlock.html:3
+msgid "Verify account"
+msgstr ""
+
+#: templates/unlock.txt:2
+msgid "Verify account:"
+msgstr ""
+
+#: templates/verify.html:2 templates/verify.txt:1
+msgid "Almost there"
+msgstr ""
+
+#: templates/verify.html:3 templates/verify.txt:2
+msgid "%(email)s, you're one click away from verifying your Firefox Account."
+msgstr ""
+
+#: templates/verify.html:4
+msgid "Verify"
+msgstr ""
+
+#: templates/verify.txt:3
+msgid "Verify:"
 msgstr ""

--- a/locale/es/LC_MESSAGES/server.po
+++ b/locale/es/LC_MESSAGES/server.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-02-20 19:15+0000\n"
+"POT-Creation-Date: 2015-02-25 18:58+0000\n"
 "PO-Revision-Date: 2014-10-17 12:22+0000\n"
 "Last-Translator: Inma <inma.barrios@mozilla-hispano.org>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -19,7 +19,8 @@ msgstr ""
 #: server/templates/pages/src/503.html:1
 #: server/templates/pages/src/index.html:1
 #: server/templates/pages/src/privacy.html:1
-#: server/templates/pages/src/terms.html:1
+#: server/templates/pages/src/terms.html:1 templates/reset.html:1
+#: templates/unlock.html:1 templates/verify.html:1
 msgid "Firefox Accounts"
 msgstr "Firefox Accounts"
 
@@ -101,47 +102,76 @@ msgstr "Servicios en la nube de Firefox"
 msgid "Terms of Service"
 msgstr "Términos del servicio"
 
-#~ msgid "Are you sure?"
-#~ msgstr "¿Seguro?"
+#: templates/reset.html:2 templates/reset.txt:1
+msgid "Are you sure?"
+msgstr "¿Seguro?"
 
-#~ msgid "Please confirm that you'd like to reset the password for %(email)s."
-#~ msgstr "Confirma que deseas restablecer la contraseña de %(email)s."
+#: templates/reset.html:3 templates/reset.txt:2
+msgid "Please confirm that you'd like to reset the password for %(email)s."
+msgstr "Confirma que deseas restablecer la contraseña de %(email)s."
 
-#~ msgid "Reset password"
-#~ msgstr "Restablecer contraseña"
+#: templates/reset.html:4
+msgid "Reset password"
+msgstr "Restablecer contraseña"
 
-#~ msgid ""
-#~ "This is an automated email; if you received it in error, no action is "
-#~ "required."
-#~ msgstr ""
-#~ "Es un correo automatizado. Si recibiste este correo por error, no es "
-#~ "necesario que hagas nada."
+#: templates/reset.html:5 templates/reset.txt:4 templates/unlock.html:4
+#: templates/unlock.txt:3 templates/verify.html:5 templates/verify.txt:4
+msgid ""
+"This is an automated email; if you received it in error, no action is "
+"required."
+msgstr ""
+"Es un correo automatizado. Si recibiste este correo por error, no es "
+"necesario que hagas nada."
 
-#~ msgid ""
-#~ "For more information, please visit <a href='https://support.mozilla."
-#~ "org'>Mozilla Support</a>"
-#~ msgstr ""
-#~ "Si quieres informarte, visita la <a href='https://support.mozilla."
-#~ "org'>Ayuda de Mozilla</a>"
+#: templates/reset.html:6 templates/unlock.html:5 templates/verify.html:6
+msgid ""
+"For more information, please visit <a href='https://support.mozilla."
+"org'>Mozilla Support</a>"
+msgstr ""
+"Si quieres informarte, visita la <a href='https://support.mozilla.org'>Ayuda "
+"de Mozilla</a>"
 
-#~ msgid "Reset password:"
-#~ msgstr "Restablecer contraseña:"
+#: templates/reset.txt:3
+msgid "Reset password:"
+msgstr "Restablecer contraseña:"
 
-#~ msgid "For more information, please visit https://support.mozilla.org"
-#~ msgstr "Si quieres informarte, visita https://support.mozilla.org"
+#: templates/reset.txt:5 templates/unlock.txt:4 templates/verify.txt:5
+msgid "For more information, please visit https://support.mozilla.org"
+msgstr "Si quieres informarte, visita https://support.mozilla.org"
+
+#: templates/unlock.html:2 templates/unlock.txt:1
+msgid ""
+"For security reasons your Firefox Account was put on lockdown. To perform "
+"account-level activities, please click the link to re-verify your account "
+"now."
+msgstr ""
+
+#: templates/unlock.html:3
+msgid "Verify account"
+msgstr ""
+
+#: templates/unlock.txt:2
+msgid "Verify account:"
+msgstr ""
+
+#: templates/verify.html:2 templates/verify.txt:1
+msgid "Almost there"
+msgstr ""
+
+#: templates/verify.html:3 templates/verify.txt:2
+msgid "%(email)s, you're one click away from verifying your Firefox Account."
+msgstr "%(email)s, estás a nada de verificar tu cuenta de Firefox."
+
+#: templates/verify.html:4
+msgid "Verify"
+msgstr "Verificar"
+
+#: templates/verify.txt:3
+msgid "Verify:"
+msgstr "Verificar:"
 
 #~ msgid "Congratulations!"
 #~ msgstr "¡Felicidades!"
-
-#~ msgid ""
-#~ "%(email)s, you're one click away from verifying your Firefox Account."
-#~ msgstr "%(email)s, estás a nada de verificar tu cuenta de Firefox."
-
-#~ msgid "Verify"
-#~ msgstr "Verificar"
-
-#~ msgid "Verify:"
-#~ msgstr "Verificar:"
 
 #~ msgid "Verify your account"
 #~ msgstr "Verifica tu cuenta"

--- a/locale/es_AR/LC_MESSAGES/server.po
+++ b/locale/es_AR/LC_MESSAGES/server.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-02-20 19:15+0000\n"
+"POT-Creation-Date: 2015-02-25 18:58+0000\n"
 "PO-Revision-Date: 2014-05-19 01:48+0000\n"
 "Last-Translator: Hernan <hernanadc@gmail.com>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -19,7 +19,8 @@ msgstr ""
 #: server/templates/pages/src/503.html:1
 #: server/templates/pages/src/index.html:1
 #: server/templates/pages/src/privacy.html:1
-#: server/templates/pages/src/terms.html:1
+#: server/templates/pages/src/terms.html:1 templates/reset.html:1
+#: templates/unlock.html:1 templates/verify.html:1
 msgid "Firefox Accounts"
 msgstr "Firefox Accounts"
 
@@ -100,47 +101,76 @@ msgstr "Servicios en la nube de Firefox"
 msgid "Terms of Service"
 msgstr "Términos de servicio"
 
-#~ msgid "Are you sure?"
-#~ msgstr "¿Estás seguro?"
+#: templates/reset.html:2 templates/reset.txt:1
+msgid "Are you sure?"
+msgstr "¿Estás seguro?"
 
-#~ msgid "Please confirm that you'd like to reset the password for %(email)s."
-#~ msgstr "Confirmá que querés restablecer la contraseña para %(email)s."
+#: templates/reset.html:3 templates/reset.txt:2
+msgid "Please confirm that you'd like to reset the password for %(email)s."
+msgstr "Confirmá que querés restablecer la contraseña para %(email)s."
 
-#~ msgid "Reset password"
-#~ msgstr "Restablecer contraseña"
+#: templates/reset.html:4
+msgid "Reset password"
+msgstr "Restablecer contraseña"
 
-#~ msgid ""
-#~ "This is an automated email; if you received it in error, no action is "
-#~ "required."
-#~ msgstr ""
-#~ "Este es un correo electrónico automático; si lo recibiste por error, no "
-#~ "debes hacer nada."
+#: templates/reset.html:5 templates/reset.txt:4 templates/unlock.html:4
+#: templates/unlock.txt:3 templates/verify.html:5 templates/verify.txt:4
+msgid ""
+"This is an automated email; if you received it in error, no action is "
+"required."
+msgstr ""
+"Este es un correo electrónico automático; si lo recibiste por error, no "
+"debes hacer nada."
 
-#~ msgid ""
-#~ "For more information, please visit <a href='https://support.mozilla."
-#~ "org'>Mozilla Support</a>"
-#~ msgstr ""
-#~ "Para recibir más información, visitá la <a href='https://support.mozilla."
-#~ "org'>Ayuda de Mozilla</a>                "
+#: templates/reset.html:6 templates/unlock.html:5 templates/verify.html:6
+msgid ""
+"For more information, please visit <a href='https://support.mozilla."
+"org'>Mozilla Support</a>"
+msgstr ""
+"Para recibir más información, visitá la <a href='https://support.mozilla."
+"org'>Ayuda de Mozilla</a>                "
 
-#~ msgid "Reset password:"
-#~ msgstr "Restablecer contraseña:"
+#: templates/reset.txt:3
+msgid "Reset password:"
+msgstr "Restablecer contraseña:"
 
-#~ msgid "For more information, please visit https://support.mozilla.org"
-#~ msgstr "Para más información, por favor visitá https://support.mozilla.org"
+#: templates/reset.txt:5 templates/unlock.txt:4 templates/verify.txt:5
+msgid "For more information, please visit https://support.mozilla.org"
+msgstr "Para más información, por favor visitá https://support.mozilla.org"
+
+#: templates/unlock.html:2 templates/unlock.txt:1
+msgid ""
+"For security reasons your Firefox Account was put on lockdown. To perform "
+"account-level activities, please click the link to re-verify your account "
+"now."
+msgstr ""
+
+#: templates/unlock.html:3
+msgid "Verify account"
+msgstr ""
+
+#: templates/unlock.txt:2
+msgid "Verify account:"
+msgstr ""
+
+#: templates/verify.html:2 templates/verify.txt:1
+msgid "Almost there"
+msgstr ""
+
+#: templates/verify.html:3 templates/verify.txt:2
+msgid "%(email)s, you're one click away from verifying your Firefox Account."
+msgstr "%(email)s, estás a un clic de verificar tu cuenta de Firefox."
+
+#: templates/verify.html:4
+msgid "Verify"
+msgstr "Verificar"
+
+#: templates/verify.txt:3
+msgid "Verify:"
+msgstr "Verificar:"
 
 #~ msgid "Congratulations!"
 #~ msgstr "¡Felicitaciones!"
-
-#~ msgid ""
-#~ "%(email)s, you're one click away from verifying your Firefox Account."
-#~ msgstr "%(email)s, estás a un clic de verificar tu cuenta de Firefox."
-
-#~ msgid "Verify"
-#~ msgstr "Verificar"
-
-#~ msgid "Verify:"
-#~ msgstr "Verificar:"
 
 #~ msgid "Verify your account"
 #~ msgstr "Verificá tu cuenta"

--- a/locale/es_CL/LC_MESSAGES/server.po
+++ b/locale/es_CL/LC_MESSAGES/server.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-02-20 19:15+0000\n"
+"POT-Creation-Date: 2015-02-25 18:58+0000\n"
 "PO-Revision-Date: 2014-10-13 00:37+0000\n"
 "Last-Translator: Richard <>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -19,7 +19,8 @@ msgstr ""
 #: server/templates/pages/src/503.html:1
 #: server/templates/pages/src/index.html:1
 #: server/templates/pages/src/privacy.html:1
-#: server/templates/pages/src/terms.html:1
+#: server/templates/pages/src/terms.html:1 templates/reset.html:1
+#: templates/unlock.html:1 templates/verify.html:1
 msgid "Firefox Accounts"
 msgstr "Firefox Accounts"
 
@@ -102,48 +103,77 @@ msgstr "Servicios de Firefox en la nube"
 msgid "Terms of Service"
 msgstr "Términos del servicio"
 
-#~ msgid "Are you sure?"
-#~ msgstr "¿Estás seguro?"
+#: templates/reset.html:2 templates/reset.txt:1
+msgid "Are you sure?"
+msgstr "¿Estás seguro?"
 
-#~ msgid "Please confirm that you'd like to reset the password for %(email)s."
-#~ msgstr ""
-#~ "Por favor, confirma que deseas restablecer la contraseña para %(email)s."
+#: templates/reset.html:3 templates/reset.txt:2
+msgid "Please confirm that you'd like to reset the password for %(email)s."
+msgstr ""
+"Por favor, confirma que deseas restablecer la contraseña para %(email)s."
 
-#~ msgid "Reset password"
-#~ msgstr "Reiniciar contraseña"
+#: templates/reset.html:4
+msgid "Reset password"
+msgstr "Reiniciar contraseña"
 
-#~ msgid ""
-#~ "This is an automated email; if you received it in error, no action is "
-#~ "required."
-#~ msgstr ""
-#~ "Este es un correo automatizado. Si lo recibiste por error, no necesitas "
-#~ "hacer nada."
+#: templates/reset.html:5 templates/reset.txt:4 templates/unlock.html:4
+#: templates/unlock.txt:3 templates/verify.html:5 templates/verify.txt:4
+msgid ""
+"This is an automated email; if you received it in error, no action is "
+"required."
+msgstr ""
+"Este es un correo automatizado. Si lo recibiste por error, no necesitas "
+"hacer nada."
 
-#~ msgid ""
-#~ "For more information, please visit <a href='https://support.mozilla."
-#~ "org'>Mozilla Support</a>"
-#~ msgstr ""
-#~ "Para más inforamción, visita <a href='https://support.mozilla."
-#~ "org'>Mozilla Support</a>"
+#: templates/reset.html:6 templates/unlock.html:5 templates/verify.html:6
+msgid ""
+"For more information, please visit <a href='https://support.mozilla."
+"org'>Mozilla Support</a>"
+msgstr ""
+"Para más inforamción, visita <a href='https://support.mozilla.org'>Mozilla "
+"Support</a>"
 
-#~ msgid "Reset password:"
-#~ msgstr "Reiniciar contraseña:"
+#: templates/reset.txt:3
+msgid "Reset password:"
+msgstr "Reiniciar contraseña:"
 
-#~ msgid "For more information, please visit https://support.mozilla.org"
-#~ msgstr "Para más información, visita https://support.mozilla.org"
+#: templates/reset.txt:5 templates/unlock.txt:4 templates/verify.txt:5
+msgid "For more information, please visit https://support.mozilla.org"
+msgstr "Para más información, visita https://support.mozilla.org"
+
+#: templates/unlock.html:2 templates/unlock.txt:1
+msgid ""
+"For security reasons your Firefox Account was put on lockdown. To perform "
+"account-level activities, please click the link to re-verify your account "
+"now."
+msgstr ""
+
+#: templates/unlock.html:3
+msgid "Verify account"
+msgstr ""
+
+#: templates/unlock.txt:2
+msgid "Verify account:"
+msgstr ""
+
+#: templates/verify.html:2 templates/verify.txt:1
+msgid "Almost there"
+msgstr ""
+
+#: templates/verify.html:3 templates/verify.txt:2
+msgid "%(email)s, you're one click away from verifying your Firefox Account."
+msgstr "%(email)s, estás a punto de verificar tu cuenta de Firefox."
+
+#: templates/verify.html:4
+msgid "Verify"
+msgstr "Verificar"
+
+#: templates/verify.txt:3
+msgid "Verify:"
+msgstr "Verificar:"
 
 #~ msgid "Congratulations!"
 #~ msgstr "¡Felititaciones!"
-
-#~ msgid ""
-#~ "%(email)s, you're one click away from verifying your Firefox Account."
-#~ msgstr "%(email)s, estás a punto de verificar tu cuenta de Firefox."
-
-#~ msgid "Verify"
-#~ msgstr "Verificar"
-
-#~ msgid "Verify:"
-#~ msgstr "Verificar:"
 
 #~ msgid "Verify your account"
 #~ msgstr "Verifica tu cuenta"

--- a/locale/es_ES/LC_MESSAGES/server.po
+++ b/locale/es_ES/LC_MESSAGES/server.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-02-20 19:15+0000\n"
+"POT-Creation-Date: 2015-02-25 18:58+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "Language: \n"
@@ -15,7 +15,8 @@ msgstr ""
 #: server/templates/pages/src/503.html:1
 #: server/templates/pages/src/index.html:1
 #: server/templates/pages/src/privacy.html:1
-#: server/templates/pages/src/terms.html:1
+#: server/templates/pages/src/terms.html:1 templates/reset.html:1
+#: templates/unlock.html:1 templates/verify.html:1
 msgid "Firefox Accounts"
 msgstr ""
 
@@ -87,4 +88,68 @@ msgstr ""
 #: server/templates/pages/src/terms.html:2
 #: server/templates/pages/src/terms.html:5
 msgid "Terms of Service"
+msgstr ""
+
+#: templates/reset.html:2 templates/reset.txt:1
+msgid "Are you sure?"
+msgstr ""
+
+#: templates/reset.html:3 templates/reset.txt:2
+msgid "Please confirm that you'd like to reset the password for %(email)s."
+msgstr ""
+
+#: templates/reset.html:4
+msgid "Reset password"
+msgstr ""
+
+#: templates/reset.html:5 templates/reset.txt:4 templates/unlock.html:4
+#: templates/unlock.txt:3 templates/verify.html:5 templates/verify.txt:4
+msgid ""
+"This is an automated email; if you received it in error, no action is "
+"required."
+msgstr ""
+
+#: templates/reset.html:6 templates/unlock.html:5 templates/verify.html:6
+msgid ""
+"For more information, please visit <a href='https://support.mozilla."
+"org'>Mozilla Support</a>"
+msgstr ""
+
+#: templates/reset.txt:3
+msgid "Reset password:"
+msgstr ""
+
+#: templates/reset.txt:5 templates/unlock.txt:4 templates/verify.txt:5
+msgid "For more information, please visit https://support.mozilla.org"
+msgstr ""
+
+#: templates/unlock.html:2 templates/unlock.txt:1
+msgid ""
+"For security reasons your Firefox Account was put on lockdown. To perform "
+"account-level activities, please click the link to re-verify your account "
+"now."
+msgstr ""
+
+#: templates/unlock.html:3
+msgid "Verify account"
+msgstr ""
+
+#: templates/unlock.txt:2
+msgid "Verify account:"
+msgstr ""
+
+#: templates/verify.html:2 templates/verify.txt:1
+msgid "Almost there"
+msgstr ""
+
+#: templates/verify.html:3 templates/verify.txt:2
+msgid "%(email)s, you're one click away from verifying your Firefox Account."
+msgstr ""
+
+#: templates/verify.html:4
+msgid "Verify"
+msgstr ""
+
+#: templates/verify.txt:3
+msgid "Verify:"
 msgstr ""

--- a/locale/es_MX/LC_MESSAGES/server.po
+++ b/locale/es_MX/LC_MESSAGES/server.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-02-20 19:15+0000\n"
+"POT-Creation-Date: 2015-02-25 18:58+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,7 +17,8 @@ msgstr ""
 #: server/templates/pages/src/503.html:1
 #: server/templates/pages/src/index.html:1
 #: server/templates/pages/src/privacy.html:1
-#: server/templates/pages/src/terms.html:1
+#: server/templates/pages/src/terms.html:1 templates/reset.html:1
+#: templates/unlock.html:1 templates/verify.html:1
 msgid "Firefox Accounts"
 msgstr ""
 
@@ -89,4 +90,68 @@ msgstr ""
 #: server/templates/pages/src/terms.html:2
 #: server/templates/pages/src/terms.html:5
 msgid "Terms of Service"
+msgstr ""
+
+#: templates/reset.html:2 templates/reset.txt:1
+msgid "Are you sure?"
+msgstr ""
+
+#: templates/reset.html:3 templates/reset.txt:2
+msgid "Please confirm that you'd like to reset the password for %(email)s."
+msgstr ""
+
+#: templates/reset.html:4
+msgid "Reset password"
+msgstr ""
+
+#: templates/reset.html:5 templates/reset.txt:4 templates/unlock.html:4
+#: templates/unlock.txt:3 templates/verify.html:5 templates/verify.txt:4
+msgid ""
+"This is an automated email; if you received it in error, no action is "
+"required."
+msgstr ""
+
+#: templates/reset.html:6 templates/unlock.html:5 templates/verify.html:6
+msgid ""
+"For more information, please visit <a href='https://support.mozilla."
+"org'>Mozilla Support</a>"
+msgstr ""
+
+#: templates/reset.txt:3
+msgid "Reset password:"
+msgstr ""
+
+#: templates/reset.txt:5 templates/unlock.txt:4 templates/verify.txt:5
+msgid "For more information, please visit https://support.mozilla.org"
+msgstr ""
+
+#: templates/unlock.html:2 templates/unlock.txt:1
+msgid ""
+"For security reasons your Firefox Account was put on lockdown. To perform "
+"account-level activities, please click the link to re-verify your account "
+"now."
+msgstr ""
+
+#: templates/unlock.html:3
+msgid "Verify account"
+msgstr ""
+
+#: templates/unlock.txt:2
+msgid "Verify account:"
+msgstr ""
+
+#: templates/verify.html:2 templates/verify.txt:1
+msgid "Almost there"
+msgstr ""
+
+#: templates/verify.html:3 templates/verify.txt:2
+msgid "%(email)s, you're one click away from verifying your Firefox Account."
+msgstr ""
+
+#: templates/verify.html:4
+msgid "Verify"
+msgstr ""
+
+#: templates/verify.txt:3
+msgid "Verify:"
 msgstr ""

--- a/locale/et/LC_MESSAGES/server.po
+++ b/locale/et/LC_MESSAGES/server.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-02-20 19:15+0000\n"
+"POT-Creation-Date: 2015-02-25 18:58+0000\n"
 "PO-Revision-Date: 2014-11-04 21:01+0000\n"
 "Last-Translator: Merike <merike.sell@eesti.ee>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -19,7 +19,8 @@ msgstr ""
 #: server/templates/pages/src/503.html:1
 #: server/templates/pages/src/index.html:1
 #: server/templates/pages/src/privacy.html:1
-#: server/templates/pages/src/terms.html:1
+#: server/templates/pages/src/terms.html:1 templates/reset.html:1
+#: templates/unlock.html:1 templates/verify.html:1
 msgid "Firefox Accounts"
 msgstr "Firefoxi kontod"
 
@@ -101,48 +102,76 @@ msgstr "Firefoxi pilveteenused"
 msgid "Terms of Service"
 msgstr "Teenuste tingimused"
 
-#~ msgid "Are you sure?"
-#~ msgstr "Kas oled ikka kindel?"
+#: templates/reset.html:2 templates/reset.txt:1
+msgid "Are you sure?"
+msgstr "Kas oled ikka kindel?"
 
-#~ msgid "Please confirm that you'd like to reset the password for %(email)s."
-#~ msgstr "Palun kinnita, et soovid lähtestada konto %(email)s parooli."
+#: templates/reset.html:3 templates/reset.txt:2
+msgid "Please confirm that you'd like to reset the password for %(email)s."
+msgstr "Palun kinnita, et soovid lähtestada konto %(email)s parooli."
 
-#~ msgid "Reset password"
-#~ msgstr "Lähtesta parool"
+#: templates/reset.html:4
+msgid "Reset password"
+msgstr "Lähtesta parool"
 
-#~ msgid ""
-#~ "This is an automated email; if you received it in error, no action is "
-#~ "required."
-#~ msgstr ""
-#~ "See e-kiri on saadetud automaatselt. Kui sa ei tellinud seda, siis ei ole "
-#~ "sul vaja midagi teha."
+#: templates/reset.html:5 templates/reset.txt:4 templates/unlock.html:4
+#: templates/unlock.txt:3 templates/verify.html:5 templates/verify.txt:4
+msgid ""
+"This is an automated email; if you received it in error, no action is "
+"required."
+msgstr ""
+"See e-kiri on saadetud automaatselt. Kui sa ei tellinud seda, siis ei ole "
+"sul vaja midagi teha."
 
-#~ msgid ""
-#~ "For more information, please visit <a href='https://support.mozilla."
-#~ "org'>Mozilla Support</a>"
-#~ msgstr ""
-#~ "Rohkema teabe saamiseks külasta <a href='https://support.mozilla."
-#~ "org'>Mozilla tugiveebi</a>"
+#: templates/reset.html:6 templates/unlock.html:5 templates/verify.html:6
+msgid ""
+"For more information, please visit <a href='https://support.mozilla."
+"org'>Mozilla Support</a>"
+msgstr ""
+"Rohkema teabe saamiseks külasta <a href='https://support.mozilla."
+"org'>Mozilla tugiveebi</a>"
 
-#~ msgid "Reset password:"
-#~ msgstr "Parooli lähtestamiseks klõpsa järgneval lingil:"
+#: templates/reset.txt:3
+msgid "Reset password:"
+msgstr "Parooli lähtestamiseks klõpsa järgneval lingil:"
 
-#~ msgid "For more information, please visit https://support.mozilla.org"
-#~ msgstr "Rohkema teabe saamiseks külasta https://support.mozilla.org"
+#: templates/reset.txt:5 templates/unlock.txt:4 templates/verify.txt:5
+msgid "For more information, please visit https://support.mozilla.org"
+msgstr "Rohkema teabe saamiseks külasta https://support.mozilla.org"
+
+#: templates/unlock.html:2 templates/unlock.txt:1
+msgid ""
+"For security reasons your Firefox Account was put on lockdown. To perform "
+"account-level activities, please click the link to re-verify your account "
+"now."
+msgstr ""
+
+#: templates/unlock.html:3
+msgid "Verify account"
+msgstr ""
+
+#: templates/unlock.txt:2
+msgid "Verify account:"
+msgstr ""
+
+#: templates/verify.html:2 templates/verify.txt:1
+msgid "Almost there"
+msgstr ""
+
+#: templates/verify.html:3 templates/verify.txt:2
+msgid "%(email)s, you're one click away from verifying your Firefox Account."
+msgstr "%(email)s, oled ühe klõpsu kaugusel oma Firefoxi konto kinnitamisest."
+
+#: templates/verify.html:4
+msgid "Verify"
+msgstr "Kinnita"
+
+#: templates/verify.txt:3
+msgid "Verify:"
+msgstr "Kinnitamiseks klõpsa järgneval lingil:"
 
 #~ msgid "Congratulations!"
 #~ msgstr "Õnnitleme!"
-
-#~ msgid ""
-#~ "%(email)s, you're one click away from verifying your Firefox Account."
-#~ msgstr ""
-#~ "%(email)s, oled ühe klõpsu kaugusel oma Firefoxi konto kinnitamisest."
-
-#~ msgid "Verify"
-#~ msgstr "Kinnita"
-
-#~ msgid "Verify:"
-#~ msgstr "Kinnitamiseks klõpsa järgneval lingil:"
 
 #~ msgid "Verify your account"
 #~ msgstr "Konto kinnitamine"

--- a/locale/eu/LC_MESSAGES/server.po
+++ b/locale/eu/LC_MESSAGES/server.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-02-20 19:15+0000\n"
+"POT-Creation-Date: 2015-02-25 18:58+0000\n"
 "PO-Revision-Date: 2014-10-25 17:01+0000\n"
 "Last-Translator: asiersar <asier.sarasua@gmail.com>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -19,7 +19,8 @@ msgstr ""
 #: server/templates/pages/src/503.html:1
 #: server/templates/pages/src/index.html:1
 #: server/templates/pages/src/privacy.html:1
-#: server/templates/pages/src/terms.html:1
+#: server/templates/pages/src/terms.html:1 templates/reset.html:1
+#: templates/unlock.html:1 templates/verify.html:1
 msgid "Firefox Accounts"
 msgstr "Firefoxeko kontuak"
 
@@ -102,48 +103,76 @@ msgstr "Firefoxen hodeieko zerbitzuak"
 msgid "Terms of Service"
 msgstr "Zerbitzuaren baldintzak"
 
-#~ msgid "Are you sure?"
-#~ msgstr "Ziur zaude?"
+#: templates/reset.html:2 templates/reset.txt:1
+msgid "Are you sure?"
+msgstr "Ziur zaude?"
 
-#~ msgid "Please confirm that you'd like to reset the password for %(email)s."
-#~ msgstr ""
-#~ "Berretsi mesedez %(email)s kontuaren pasahitza berrezarri nahi duzula."
+#: templates/reset.html:3 templates/reset.txt:2
+msgid "Please confirm that you'd like to reset the password for %(email)s."
+msgstr "Berretsi mesedez %(email)s kontuaren pasahitza berrezarri nahi duzula."
 
-#~ msgid "Reset password"
-#~ msgstr "Berrezarri pasahitza"
+#: templates/reset.html:4
+msgid "Reset password"
+msgstr "Berrezarri pasahitza"
 
-#~ msgid ""
-#~ "This is an automated email; if you received it in error, no action is "
-#~ "required."
-#~ msgstr ""
-#~ "Mezu hau automatikoa da; errorez jaso baduzu, ez duzu ekintzarik burutu "
-#~ "behar."
+#: templates/reset.html:5 templates/reset.txt:4 templates/unlock.html:4
+#: templates/unlock.txt:3 templates/verify.html:5 templates/verify.txt:4
+msgid ""
+"This is an automated email; if you received it in error, no action is "
+"required."
+msgstr ""
+"Mezu hau automatikoa da; errorez jaso baduzu, ez duzu ekintzarik burutu "
+"behar."
 
-#~ msgid ""
-#~ "For more information, please visit <a href='https://support.mozilla."
-#~ "org'>Mozilla Support</a>"
-#~ msgstr ""
-#~ "Informazio gehiagorako bisitatu <a href='https://support.mozilla."
-#~ "org'>Mozillaren laguntza</a>"
+#: templates/reset.html:6 templates/unlock.html:5 templates/verify.html:6
+msgid ""
+"For more information, please visit <a href='https://support.mozilla."
+"org'>Mozilla Support</a>"
+msgstr ""
+"Informazio gehiagorako bisitatu <a href='https://support.mozilla."
+"org'>Mozillaren laguntza</a>"
 
-#~ msgid "Reset password:"
-#~ msgstr "Berrezarri pasahitza:"
+#: templates/reset.txt:3
+msgid "Reset password:"
+msgstr "Berrezarri pasahitza:"
 
-#~ msgid "For more information, please visit https://support.mozilla.org"
-#~ msgstr "Informazio gehiagorako bisitatu https://support.mozilla.org"
+#: templates/reset.txt:5 templates/unlock.txt:4 templates/verify.txt:5
+msgid "For more information, please visit https://support.mozilla.org"
+msgstr "Informazio gehiagorako bisitatu https://support.mozilla.org"
+
+#: templates/unlock.html:2 templates/unlock.txt:1
+msgid ""
+"For security reasons your Firefox Account was put on lockdown. To perform "
+"account-level activities, please click the link to re-verify your account "
+"now."
+msgstr ""
+
+#: templates/unlock.html:3
+msgid "Verify account"
+msgstr ""
+
+#: templates/unlock.txt:2
+msgid "Verify account:"
+msgstr ""
+
+#: templates/verify.html:2 templates/verify.txt:1
+msgid "Almost there"
+msgstr ""
+
+#: templates/verify.html:3 templates/verify.txt:2
+msgid "%(email)s, you're one click away from verifying your Firefox Account."
+msgstr "%(email)s, zure Firefoxeko kontua egiaztatzear zaude."
+
+#: templates/verify.html:4
+msgid "Verify"
+msgstr "Egiaztatu"
+
+#: templates/verify.txt:3
+msgid "Verify:"
+msgstr "Egiaztatu:"
 
 #~ msgid "Congratulations!"
 #~ msgstr "Zorionak!"
-
-#~ msgid ""
-#~ "%(email)s, you're one click away from verifying your Firefox Account."
-#~ msgstr "%(email)s, zure Firefoxeko kontua egiaztatzear zaude."
-
-#~ msgid "Verify"
-#~ msgstr "Egiaztatu"
-
-#~ msgid "Verify:"
-#~ msgstr "Egiaztatu:"
 
 #~ msgid "Verify your account"
 #~ msgstr "Egiaztatu zure kontua"

--- a/locale/fa/LC_MESSAGES/server.po
+++ b/locale/fa/LC_MESSAGES/server.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-02-20 19:15+0000\n"
+"POT-Creation-Date: 2015-02-25 18:58+0000\n"
 "PO-Revision-Date: 2015-02-09 13:57+0000\n"
 "Last-Translator: Amir <amir_farsi@ymail.com>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -19,7 +19,8 @@ msgstr ""
 #: server/templates/pages/src/503.html:1
 #: server/templates/pages/src/index.html:1
 #: server/templates/pages/src/privacy.html:1
-#: server/templates/pages/src/terms.html:1
+#: server/templates/pages/src/terms.html:1 templates/reset.html:1
+#: templates/unlock.html:1 templates/verify.html:1
 msgid "Firefox Accounts"
 msgstr ""
 
@@ -93,8 +94,66 @@ msgstr ""
 msgid "Terms of Service"
 msgstr ""
 
-#~ msgid "Reset password"
-#~ msgstr "بازنشانی گذرواژه"
+#: templates/reset.html:2 templates/reset.txt:1
+msgid "Are you sure?"
+msgstr ""
 
-#~ msgid "Reset password:"
-#~ msgstr "بازنشانی گذرواژه:"
+#: templates/reset.html:3 templates/reset.txt:2
+msgid "Please confirm that you'd like to reset the password for %(email)s."
+msgstr ""
+
+#: templates/reset.html:4
+msgid "Reset password"
+msgstr "بازنشانی گذرواژه"
+
+#: templates/reset.html:5 templates/reset.txt:4 templates/unlock.html:4
+#: templates/unlock.txt:3 templates/verify.html:5 templates/verify.txt:4
+msgid ""
+"This is an automated email; if you received it in error, no action is "
+"required."
+msgstr ""
+
+#: templates/reset.html:6 templates/unlock.html:5 templates/verify.html:6
+msgid ""
+"For more information, please visit <a href='https://support.mozilla."
+"org'>Mozilla Support</a>"
+msgstr ""
+
+#: templates/reset.txt:3
+msgid "Reset password:"
+msgstr "بازنشانی گذرواژه:"
+
+#: templates/reset.txt:5 templates/unlock.txt:4 templates/verify.txt:5
+msgid "For more information, please visit https://support.mozilla.org"
+msgstr ""
+
+#: templates/unlock.html:2 templates/unlock.txt:1
+msgid ""
+"For security reasons your Firefox Account was put on lockdown. To perform "
+"account-level activities, please click the link to re-verify your account "
+"now."
+msgstr ""
+
+#: templates/unlock.html:3
+msgid "Verify account"
+msgstr ""
+
+#: templates/unlock.txt:2
+msgid "Verify account:"
+msgstr ""
+
+#: templates/verify.html:2 templates/verify.txt:1
+msgid "Almost there"
+msgstr ""
+
+#: templates/verify.html:3 templates/verify.txt:2
+msgid "%(email)s, you're one click away from verifying your Firefox Account."
+msgstr ""
+
+#: templates/verify.html:4
+msgid "Verify"
+msgstr ""
+
+#: templates/verify.txt:3
+msgid "Verify:"
+msgstr ""

--- a/locale/ff/LC_MESSAGES/server.po
+++ b/locale/ff/LC_MESSAGES/server.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-02-20 19:15+0000\n"
+"POT-Creation-Date: 2015-02-25 18:58+0000\n"
 "PO-Revision-Date: 2014-05-16 01:09+0200\n"
 "Last-Translator: Ibrahima SARR <ibrahima.sarr@pulaagu.com>\n"
 "Language-Team: FULAH LOCALIZATION\n"
@@ -18,7 +18,8 @@ msgstr ""
 #: server/templates/pages/src/503.html:1
 #: server/templates/pages/src/index.html:1
 #: server/templates/pages/src/privacy.html:1
-#: server/templates/pages/src/terms.html:1
+#: server/templates/pages/src/terms.html:1 templates/reset.html:1
+#: templates/unlock.html:1 templates/verify.html:1
 msgid "Firefox Accounts"
 msgstr "Konte Firefox"
 
@@ -99,47 +100,75 @@ msgstr "Carwe ruulde Firefox"
 msgid "Terms of Service"
 msgstr "Sarɗiiji Carwe"
 
-#~ msgid "Are you sure?"
-#~ msgstr "Aɗa yenanaa?"
+#: templates/reset.html:2 templates/reset.txt:1
+msgid "Are you sure?"
+msgstr "Aɗa yenanaa?"
 
-#~ msgid "Please confirm that you'd like to reset the password for %(email)s."
-#~ msgstr "Tiiɗno teeŋtin wonde aɗa yiɗi firlitde finnde maa e %(email)s."
+#: templates/reset.html:3 templates/reset.txt:2
+msgid "Please confirm that you'd like to reset the password for %(email)s."
+msgstr "Tiiɗno teeŋtin wonde aɗa yiɗi firlitde finnde maa e %(email)s."
 
-#~ msgid "Reset password"
-#~ msgstr "Firlit finnde"
+#: templates/reset.html:4
+msgid "Reset password"
+msgstr "Firlit finnde"
 
-#~ msgid ""
-#~ "This is an automated email; if you received it in error, no action is "
-#~ "required."
-#~ msgstr ""
-#~ "Ɗuum ko iimeel jaajo; so a heɓiimo e juumre, alaa ko pot-ɗaa waɗde hay "
-#~ "baɗte."
+#: templates/reset.html:5 templates/reset.txt:4 templates/unlock.html:4
+#: templates/unlock.txt:3 templates/verify.html:5 templates/verify.txt:4
+msgid ""
+"This is an automated email; if you received it in error, no action is "
+"required."
+msgstr ""
+"Ɗuum ko iimeel jaajo; so a heɓiimo e juumre, alaa ko pot-ɗaa waɗde hay baɗte."
 
-#~ msgid ""
-#~ "For more information, please visit <a href='https://support.mozilla."
-#~ "org'>Mozilla Support</a>"
-#~ msgstr ""
-#~ "Ngam ɓeydude humpito, tiiɗno yillo <a href='https://support.mozilla."
-#~ "org'>Wallitorde Mozilla</a>"
+#: templates/reset.html:6 templates/unlock.html:5 templates/verify.html:6
+msgid ""
+"For more information, please visit <a href='https://support.mozilla."
+"org'>Mozilla Support</a>"
+msgstr ""
+"Ngam ɓeydude humpito, tiiɗno yillo <a href='https://support.mozilla."
+"org'>Wallitorde Mozilla</a>"
 
-#~ msgid "Reset password:"
-#~ msgstr "Firlit finnde:"
+#: templates/reset.txt:3
+msgid "Reset password:"
+msgstr "Firlit finnde:"
 
-#~ msgid "For more information, please visit https://support.mozilla.org"
-#~ msgstr "Ngam ɓeydude humpito, tiiɗno yillo https://support.mozilla.org"
+#: templates/reset.txt:5 templates/unlock.txt:4 templates/verify.txt:5
+msgid "For more information, please visit https://support.mozilla.org"
+msgstr "Ngam ɓeydude humpito, tiiɗno yillo https://support.mozilla.org"
+
+#: templates/unlock.html:2 templates/unlock.txt:1
+msgid ""
+"For security reasons your Firefox Account was put on lockdown. To perform "
+"account-level activities, please click the link to re-verify your account "
+"now."
+msgstr ""
+
+#: templates/unlock.html:3
+msgid "Verify account"
+msgstr ""
+
+#: templates/unlock.txt:2
+msgid "Verify account:"
+msgstr ""
+
+#: templates/verify.html:2 templates/verify.txt:1
+msgid "Almost there"
+msgstr ""
+
+#: templates/verify.html:3 templates/verify.txt:2
+msgid "%(email)s, you're one click away from verifying your Firefox Account."
+msgstr "%(email)s, heddii tan ko dobannde ngam ƴeewtagol Konte Firefox maa."
+
+#: templates/verify.html:4
+msgid "Verify"
+msgstr "Ƴeewto"
+
+#: templates/verify.txt:3
+msgid "Verify:"
+msgstr "Ƴeewto:"
 
 #~ msgid "Congratulations!"
 #~ msgstr "Woyyoo maa!"
-
-#~ msgid ""
-#~ "%(email)s, you're one click away from verifying your Firefox Account."
-#~ msgstr "%(email)s, heddii tan ko dobannde ngam ƴeewtagol Konte Firefox maa."
-
-#~ msgid "Verify"
-#~ msgstr "Ƴeewto"
-
-#~ msgid "Verify:"
-#~ msgstr "Ƴeewto:"
 
 #~ msgid "Verify your account"
 #~ msgstr "Ƴeewto konte maa"

--- a/locale/fi/LC_MESSAGES/server.po
+++ b/locale/fi/LC_MESSAGES/server.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-02-20 19:15+0000\n"
+"POT-Creation-Date: 2015-02-25 18:58+0000\n"
 "PO-Revision-Date: 2015-01-10 14:17+0000\n"
 "Last-Translator: Ville <ville.pohjanheimo@gmail.com>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -19,7 +19,8 @@ msgstr ""
 #: server/templates/pages/src/503.html:1
 #: server/templates/pages/src/index.html:1
 #: server/templates/pages/src/privacy.html:1
-#: server/templates/pages/src/terms.html:1
+#: server/templates/pages/src/terms.html:1 templates/reset.html:1
+#: templates/unlock.html:1 templates/verify.html:1
 msgid "Firefox Accounts"
 msgstr "Firefox-tilit"
 
@@ -102,47 +103,76 @@ msgstr "Firefox pilvipalvelut"
 msgid "Terms of Service"
 msgstr "Käyttöehdot"
 
-#~ msgid "Are you sure?"
-#~ msgstr "Oletko varma?"
+#: templates/reset.html:2 templates/reset.txt:1
+msgid "Are you sure?"
+msgstr "Oletko varma?"
 
-#~ msgid "Please confirm that you'd like to reset the password for %(email)s."
-#~ msgstr "Nollataanko varmasti salasana tilille %(email)s?"
+#: templates/reset.html:3 templates/reset.txt:2
+msgid "Please confirm that you'd like to reset the password for %(email)s."
+msgstr "Nollataanko varmasti salasana tilille %(email)s?"
 
-#~ msgid "Reset password"
-#~ msgstr "Nollaa salasana"
+#: templates/reset.html:4
+msgid "Reset password"
+msgstr "Nollaa salasana"
 
-#~ msgid ""
-#~ "This is an automated email; if you received it in error, no action is "
-#~ "required."
-#~ msgstr ""
-#~ "Tämä on automaattisesti lähetetty viesti. Jos sait sen vahingossa, ei "
-#~ "sinun tarvitse tehdä mitään."
+#: templates/reset.html:5 templates/reset.txt:4 templates/unlock.html:4
+#: templates/unlock.txt:3 templates/verify.html:5 templates/verify.txt:4
+msgid ""
+"This is an automated email; if you received it in error, no action is "
+"required."
+msgstr ""
+"Tämä on automaattisesti lähetetty viesti. Jos sait sen vahingossa, ei sinun "
+"tarvitse tehdä mitään."
 
-#~ msgid ""
-#~ "For more information, please visit <a href='https://support.mozilla."
-#~ "org'>Mozilla Support</a>"
-#~ msgstr ""
-#~ "Lisätietoja saat <a href='https://support.mozilla.org'>Mozillan "
-#~ "tukisivustolta</a>"
+#: templates/reset.html:6 templates/unlock.html:5 templates/verify.html:6
+msgid ""
+"For more information, please visit <a href='https://support.mozilla."
+"org'>Mozilla Support</a>"
+msgstr ""
+"Lisätietoja saat <a href='https://support.mozilla.org'>Mozillan "
+"tukisivustolta</a>"
 
-#~ msgid "Reset password:"
-#~ msgstr "Nollaa salasana:"
+#: templates/reset.txt:3
+msgid "Reset password:"
+msgstr "Nollaa salasana:"
 
-#~ msgid "For more information, please visit https://support.mozilla.org"
-#~ msgstr "Lisätietoa saat osoitteesta https://support.mozilla.org"
+#: templates/reset.txt:5 templates/unlock.txt:4 templates/verify.txt:5
+msgid "For more information, please visit https://support.mozilla.org"
+msgstr "Lisätietoa saat osoitteesta https://support.mozilla.org"
+
+#: templates/unlock.html:2 templates/unlock.txt:1
+msgid ""
+"For security reasons your Firefox Account was put on lockdown. To perform "
+"account-level activities, please click the link to re-verify your account "
+"now."
+msgstr ""
+
+#: templates/unlock.html:3
+msgid "Verify account"
+msgstr ""
+
+#: templates/unlock.txt:2
+msgid "Verify account:"
+msgstr ""
+
+#: templates/verify.html:2 templates/verify.txt:1
+msgid "Almost there"
+msgstr ""
+
+#: templates/verify.html:3 templates/verify.txt:2
+msgid "%(email)s, you're one click away from verifying your Firefox Account."
+msgstr "%(email)s napsauta vielä kerran ja olet vahvistanut Firefox-tilisi."
+
+#: templates/verify.html:4
+msgid "Verify"
+msgstr "Vahvista"
+
+#: templates/verify.txt:3
+msgid "Verify:"
+msgstr "Vahvista:"
 
 #~ msgid "Congratulations!"
 #~ msgstr "Onneksi olkoon!"
-
-#~ msgid ""
-#~ "%(email)s, you're one click away from verifying your Firefox Account."
-#~ msgstr "%(email)s napsauta vielä kerran ja olet vahvistanut Firefox-tilisi."
-
-#~ msgid "Verify"
-#~ msgstr "Vahvista"
-
-#~ msgid "Verify:"
-#~ msgstr "Vahvista:"
 
 #~ msgid "Verify your account"
 #~ msgstr "Vahvista tilisi"

--- a/locale/fr/LC_MESSAGES/server.po
+++ b/locale/fr/LC_MESSAGES/server.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2014-11-10 18:39+0000\n"
+"POT-Creation-Date: 2015-02-25 18:58+0000\n"
 "PO-Revision-Date: 2014-10-10 20:06+0000\n"
 "Last-Translator: Théo <theo.chevalier11@gmail.com>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -14,14 +14,19 @@ msgstr ""
 "X-Generator: Pootle 2.5.0\n"
 "X-POOTLE-MTIME: 1412971572.0\n"
 
-#: server/templates/pages/src/404.html:1 server/templates/pages/src/500.html:1
+#: server/templates/pages/src/400.html:1 server/templates/pages/src/404.html:1
+#: server/templates/pages/src/500.html:1 server/templates/pages/src/502.html:1
 #: server/templates/pages/src/503.html:1
 #: server/templates/pages/src/index.html:1
 #: server/templates/pages/src/privacy.html:1
-#: server/templates/pages/src/terms.html:1 server/templates/email/reset.html:1
-#: server/templates/email/verify.html:1
+#: server/templates/pages/src/terms.html:1 templates/reset.html:1
+#: templates/unlock.html:1 templates/verify.html:1
 msgid "Firefox Accounts"
 msgstr "Comptes Firefox"
+
+#: server/templates/pages/src/400.html:2
+msgid "Bad Request"
+msgstr ""
 
 #: server/templates/pages/src/404.html:2
 msgid "Page not found"
@@ -36,7 +41,7 @@ msgstr ""
 "rétablirons les liens éventuellement cassés."
 
 #: server/templates/pages/src/404.html:4 server/templates/pages/src/500.html:4
-#: server/templates/pages/src/503.html:4
+#: server/templates/pages/src/502.html:4 server/templates/pages/src/503.html:4
 msgid "Home"
 msgstr "Accueil"
 
@@ -44,13 +49,17 @@ msgstr "Accueil"
 msgid "500 Error"
 msgstr "Erreur 500"
 
-#: server/templates/pages/src/500.html:3
+#: server/templates/pages/src/500.html:3 server/templates/pages/src/502.html:3
 msgid ""
 "Oh dear, something went wrong there. We've been notified and will get "
 "working on a fix."
 msgstr ""
 "Une erreur s'est produite. Nous en avons été avertis et allons mettre au "
 "point un correctif."
+
+#: server/templates/pages/src/502.html:2
+msgid "502 Error"
+msgstr ""
 
 #: server/templates/pages/src/503.html:2
 msgid "Server busy, try again soon"
@@ -94,20 +103,20 @@ msgstr "Services en ligne de Firefox"
 msgid "Terms of Service"
 msgstr "Conditions d'utilisation"
 
-#: server/templates/email/reset.html:2 server/templates/email/reset.txt:1
+#: templates/reset.html:2 templates/reset.txt:1
 msgid "Are you sure?"
 msgstr "Voulez-vous vraiment réinitialiser le mot de passe ?"
 
-#: server/templates/email/reset.html:3 server/templates/email/reset.txt:2
+#: templates/reset.html:3 templates/reset.txt:2
 msgid "Please confirm that you'd like to reset the password for %(email)s."
 msgstr "Veuillez confirmer la réinitialisation du mot de passe pour %(email)s."
 
-#: server/templates/email/reset.html:4
+#: templates/reset.html:4
 msgid "Reset password"
 msgstr "Réinitialiser le mot de passe"
 
-#: server/templates/email/reset.html:5 server/templates/email/reset.txt:4
-#: server/templates/email/verify.html:5 server/templates/email/verify.txt:4
+#: templates/reset.html:5 templates/reset.txt:4 templates/unlock.html:4
+#: templates/unlock.txt:3 templates/verify.html:5 templates/verify.txt:4
 msgid ""
 "This is an automated email; if you received it in error, no action is "
 "required."
@@ -115,7 +124,7 @@ msgstr ""
 "Ceci est un message automatique ; si vous l'avez reçu par erreur, vous "
 "n'avez rien à faire."
 
-#: server/templates/email/reset.html:6 server/templates/email/verify.html:6
+#: templates/reset.html:6 templates/unlock.html:5 templates/verify.html:6
 msgid ""
 "For more information, please visit <a href='https://support.mozilla."
 "org'>Mozilla Support</a>"
@@ -123,38 +132,54 @@ msgstr ""
 "Pour davantage d'informations, veuillez consulter <a href='https://support."
 "mozilla.org'>l'assistance de Mozilla</a>"
 
-#: server/templates/email/reset.txt:3
+#: templates/reset.txt:3
 msgid "Reset password:"
 msgstr "Réinitialiser le mot de passe&nbsp;:"
 
-#: server/templates/email/reset.txt:5 server/templates/email/verify.txt:5
+#: templates/reset.txt:5 templates/unlock.txt:4 templates/verify.txt:5
 msgid "For more information, please visit https://support.mozilla.org"
 msgstr ""
 "Pour davantage d'informations, veuillez consulter https://support.mozilla.org"
 
-#: server/templates/email/verify.html:2 server/templates/email/verify.txt:1
-msgid "Congratulations!"
-msgstr "Félicitations !"
+#: templates/unlock.html:2 templates/unlock.txt:1
+msgid ""
+"For security reasons your Firefox Account was put on lockdown. To perform "
+"account-level activities, please click the link to re-verify your account "
+"now."
+msgstr ""
 
-#: server/templates/email/verify.html:3 server/templates/email/verify.txt:2
+#: templates/unlock.html:3
+msgid "Verify account"
+msgstr ""
+
+#: templates/unlock.txt:2
+msgid "Verify account:"
+msgstr ""
+
+#: templates/verify.html:2 templates/verify.txt:1
+msgid "Almost there"
+msgstr ""
+
+#: templates/verify.html:3 templates/verify.txt:2
 msgid "%(email)s, you're one click away from verifying your Firefox Account."
 msgstr "%(email)s, vous êtes sur le point de vérifier votre compte Firefox."
 
-#: server/templates/email/verify.html:4
+#: templates/verify.html:4
 msgid "Verify"
 msgstr "Vérifier"
 
-#: server/templates/email/verify.txt:3
+#: templates/verify.txt:3
 msgid "Verify:"
 msgstr "Vérifier&nbsp;:"
 
-#: server/lib/templates.js:63
-msgid "Verify your account"
-msgstr "Vérifier le compte"
+#~ msgid "Congratulations!"
+#~ msgstr "Félicitations !"
 
-#: server/lib/templates.js:68
-msgid "Reset your password"
-msgstr "Réinitialiser le mot de passe"
+#~ msgid "Verify your account"
+#~ msgstr "Vérifier le compte"
+
+#~ msgid "Reset your password"
+#~ msgstr "Réinitialiser le mot de passe"
 
 #~ msgid "System unavailable, try again soon"
 #~ msgstr "Système indisponible, veuillez réessayer plus tard"

--- a/locale/fy/LC_MESSAGES/server.po
+++ b/locale/fy/LC_MESSAGES/server.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-02-20 19:15+0000\n"
+"POT-Creation-Date: 2015-02-25 18:58+0000\n"
 "PO-Revision-Date: 2015-01-29 07:25+0000\n"
 "Last-Translator: Wim <fryskefirefox@gmail.com>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -19,7 +19,8 @@ msgstr ""
 #: server/templates/pages/src/503.html:1
 #: server/templates/pages/src/index.html:1
 #: server/templates/pages/src/privacy.html:1
-#: server/templates/pages/src/terms.html:1
+#: server/templates/pages/src/terms.html:1 templates/reset.html:1
+#: templates/unlock.html:1 templates/verify.html:1
 msgid "Firefox Accounts"
 msgstr "Firefox-accounts"
 
@@ -101,49 +102,78 @@ msgstr "Firefox-cloudtsjinsten"
 msgid "Terms of Service"
 msgstr "Servicebetingsten"
 
-#~ msgid "Are you sure?"
-#~ msgstr "Binne jo wis?"
+#: templates/reset.html:2 templates/reset.txt:1
+msgid "Are you sure?"
+msgstr "Binne jo wis?"
 
-#~ msgid "Please confirm that you'd like to reset the password for %(email)s."
-#~ msgstr "Befêstigje dat jo it wachtwurd foar %(email)s opnij ynstelle wolle."
+#: templates/reset.html:3 templates/reset.txt:2
+msgid "Please confirm that you'd like to reset the password for %(email)s."
+msgstr "Befêstigje dat jo it wachtwurd foar %(email)s opnij ynstelle wolle."
 
-#~ msgid "Reset password"
-#~ msgstr "Wachtwurd werinisjalisearje"
+#: templates/reset.html:4
+msgid "Reset password"
+msgstr "Wachtwurd werinisjalisearje"
 
-#~ msgid ""
-#~ "This is an automated email; if you received it in error, no action is "
-#~ "required."
-#~ msgstr ""
-#~ "Dit is in automatysk e-mailberjocht; as jo it troch fersin ûntfongen "
-#~ "hawwe, hoege jo neat te dwaan."
+#: templates/reset.html:5 templates/reset.txt:4 templates/unlock.html:4
+#: templates/unlock.txt:3 templates/verify.html:5 templates/verify.txt:4
+msgid ""
+"This is an automated email; if you received it in error, no action is "
+"required."
+msgstr ""
+"Dit is in automatysk e-mailberjocht; as jo it troch fersin ûntfongen hawwe, "
+"hoege jo neat te dwaan."
 
-#~ msgid ""
-#~ "For more information, please visit <a href='https://support.mozilla."
-#~ "org'>Mozilla Support</a>"
-#~ msgstr ""
-#~ "Besykje foar mear ynformaasje <a href='https://support.mozilla."
-#~ "org'>Mozilla Support</a>"
+#: templates/reset.html:6 templates/unlock.html:5 templates/verify.html:6
+msgid ""
+"For more information, please visit <a href='https://support.mozilla."
+"org'>Mozilla Support</a>"
+msgstr ""
+"Besykje foar mear ynformaasje <a href='https://support.mozilla.org'>Mozilla "
+"Support</a>"
 
-#~ msgid "Reset password:"
-#~ msgstr "Wachtwurd werinisjalisearje:"
+#: templates/reset.txt:3
+msgid "Reset password:"
+msgstr "Wachtwurd werinisjalisearje:"
 
-#~ msgid "For more information, please visit https://support.mozilla.org"
-#~ msgstr "Besykje foar mear ynformaasje https://support.mozilla.org"
+#: templates/reset.txt:5 templates/unlock.txt:4 templates/verify.txt:5
+msgid "For more information, please visit https://support.mozilla.org"
+msgstr "Besykje foar mear ynformaasje https://support.mozilla.org"
+
+#: templates/unlock.html:2 templates/unlock.txt:1
+msgid ""
+"For security reasons your Firefox Account was put on lockdown. To perform "
+"account-level activities, please click the link to re-verify your account "
+"now."
+msgstr ""
+
+#: templates/unlock.html:3
+msgid "Verify account"
+msgstr ""
+
+#: templates/unlock.txt:2
+msgid "Verify account:"
+msgstr ""
+
+#: templates/verify.html:2 templates/verify.txt:1
+msgid "Almost there"
+msgstr ""
+
+#: templates/verify.html:3 templates/verify.txt:2
+msgid "%(email)s, you're one click away from verifying your Firefox Account."
+msgstr ""
+"%(email)s, jo binne noch ien mûsklik ôf fan ferifikaasje fan jo Firefox-"
+"account."
+
+#: templates/verify.html:4
+msgid "Verify"
+msgstr "Ferifiearje"
+
+#: templates/verify.txt:3
+msgid "Verify:"
+msgstr "Ferifiearje:"
 
 #~ msgid "Congratulations!"
 #~ msgstr "Lokwinske!"
-
-#~ msgid ""
-#~ "%(email)s, you're one click away from verifying your Firefox Account."
-#~ msgstr ""
-#~ "%(email)s, jo binne noch ien mûsklik ôf fan ferifikaasje fan jo Firefox-"
-#~ "account."
-
-#~ msgid "Verify"
-#~ msgstr "Ferifiearje"
-
-#~ msgid "Verify:"
-#~ msgstr "Ferifiearje:"
 
 #~ msgid "Verify your account"
 #~ msgstr "Ferifiearje jo account"

--- a/locale/fy_NL/LC_MESSAGES/server.po
+++ b/locale/fy_NL/LC_MESSAGES/server.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-02-20 19:15+0000\n"
+"POT-Creation-Date: 2015-02-25 18:58+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "Language: \n"
@@ -15,7 +15,8 @@ msgstr ""
 #: server/templates/pages/src/503.html:1
 #: server/templates/pages/src/index.html:1
 #: server/templates/pages/src/privacy.html:1
-#: server/templates/pages/src/terms.html:1
+#: server/templates/pages/src/terms.html:1 templates/reset.html:1
+#: templates/unlock.html:1 templates/verify.html:1
 msgid "Firefox Accounts"
 msgstr ""
 
@@ -87,4 +88,68 @@ msgstr ""
 #: server/templates/pages/src/terms.html:2
 #: server/templates/pages/src/terms.html:5
 msgid "Terms of Service"
+msgstr ""
+
+#: templates/reset.html:2 templates/reset.txt:1
+msgid "Are you sure?"
+msgstr ""
+
+#: templates/reset.html:3 templates/reset.txt:2
+msgid "Please confirm that you'd like to reset the password for %(email)s."
+msgstr ""
+
+#: templates/reset.html:4
+msgid "Reset password"
+msgstr ""
+
+#: templates/reset.html:5 templates/reset.txt:4 templates/unlock.html:4
+#: templates/unlock.txt:3 templates/verify.html:5 templates/verify.txt:4
+msgid ""
+"This is an automated email; if you received it in error, no action is "
+"required."
+msgstr ""
+
+#: templates/reset.html:6 templates/unlock.html:5 templates/verify.html:6
+msgid ""
+"For more information, please visit <a href='https://support.mozilla."
+"org'>Mozilla Support</a>"
+msgstr ""
+
+#: templates/reset.txt:3
+msgid "Reset password:"
+msgstr ""
+
+#: templates/reset.txt:5 templates/unlock.txt:4 templates/verify.txt:5
+msgid "For more information, please visit https://support.mozilla.org"
+msgstr ""
+
+#: templates/unlock.html:2 templates/unlock.txt:1
+msgid ""
+"For security reasons your Firefox Account was put on lockdown. To perform "
+"account-level activities, please click the link to re-verify your account "
+"now."
+msgstr ""
+
+#: templates/unlock.html:3
+msgid "Verify account"
+msgstr ""
+
+#: templates/unlock.txt:2
+msgid "Verify account:"
+msgstr ""
+
+#: templates/verify.html:2 templates/verify.txt:1
+msgid "Almost there"
+msgstr ""
+
+#: templates/verify.html:3 templates/verify.txt:2
+msgid "%(email)s, you're one click away from verifying your Firefox Account."
+msgstr ""
+
+#: templates/verify.html:4
+msgid "Verify"
+msgstr ""
+
+#: templates/verify.txt:3
+msgid "Verify:"
 msgstr ""

--- a/locale/ga/LC_MESSAGES/server.po
+++ b/locale/ga/LC_MESSAGES/server.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-02-20 19:15+0000\n"
+"POT-Creation-Date: 2015-02-25 18:58+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,7 +17,8 @@ msgstr ""
 #: server/templates/pages/src/503.html:1
 #: server/templates/pages/src/index.html:1
 #: server/templates/pages/src/privacy.html:1
-#: server/templates/pages/src/terms.html:1
+#: server/templates/pages/src/terms.html:1 templates/reset.html:1
+#: templates/unlock.html:1 templates/verify.html:1
 msgid "Firefox Accounts"
 msgstr ""
 
@@ -89,4 +90,68 @@ msgstr ""
 #: server/templates/pages/src/terms.html:2
 #: server/templates/pages/src/terms.html:5
 msgid "Terms of Service"
+msgstr ""
+
+#: templates/reset.html:2 templates/reset.txt:1
+msgid "Are you sure?"
+msgstr ""
+
+#: templates/reset.html:3 templates/reset.txt:2
+msgid "Please confirm that you'd like to reset the password for %(email)s."
+msgstr ""
+
+#: templates/reset.html:4
+msgid "Reset password"
+msgstr ""
+
+#: templates/reset.html:5 templates/reset.txt:4 templates/unlock.html:4
+#: templates/unlock.txt:3 templates/verify.html:5 templates/verify.txt:4
+msgid ""
+"This is an automated email; if you received it in error, no action is "
+"required."
+msgstr ""
+
+#: templates/reset.html:6 templates/unlock.html:5 templates/verify.html:6
+msgid ""
+"For more information, please visit <a href='https://support.mozilla."
+"org'>Mozilla Support</a>"
+msgstr ""
+
+#: templates/reset.txt:3
+msgid "Reset password:"
+msgstr ""
+
+#: templates/reset.txt:5 templates/unlock.txt:4 templates/verify.txt:5
+msgid "For more information, please visit https://support.mozilla.org"
+msgstr ""
+
+#: templates/unlock.html:2 templates/unlock.txt:1
+msgid ""
+"For security reasons your Firefox Account was put on lockdown. To perform "
+"account-level activities, please click the link to re-verify your account "
+"now."
+msgstr ""
+
+#: templates/unlock.html:3
+msgid "Verify account"
+msgstr ""
+
+#: templates/unlock.txt:2
+msgid "Verify account:"
+msgstr ""
+
+#: templates/verify.html:2 templates/verify.txt:1
+msgid "Almost there"
+msgstr ""
+
+#: templates/verify.html:3 templates/verify.txt:2
+msgid "%(email)s, you're one click away from verifying your Firefox Account."
+msgstr ""
+
+#: templates/verify.html:4
+msgid "Verify"
+msgstr ""
+
+#: templates/verify.txt:3
+msgid "Verify:"
 msgstr ""

--- a/locale/ga_IE/LC_MESSAGES/server.po
+++ b/locale/ga_IE/LC_MESSAGES/server.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-02-20 19:15+0000\n"
+"POT-Creation-Date: 2015-02-25 18:58+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "Language: \n"
@@ -15,7 +15,8 @@ msgstr ""
 #: server/templates/pages/src/503.html:1
 #: server/templates/pages/src/index.html:1
 #: server/templates/pages/src/privacy.html:1
-#: server/templates/pages/src/terms.html:1
+#: server/templates/pages/src/terms.html:1 templates/reset.html:1
+#: templates/unlock.html:1 templates/verify.html:1
 msgid "Firefox Accounts"
 msgstr ""
 
@@ -87,4 +88,68 @@ msgstr ""
 #: server/templates/pages/src/terms.html:2
 #: server/templates/pages/src/terms.html:5
 msgid "Terms of Service"
+msgstr ""
+
+#: templates/reset.html:2 templates/reset.txt:1
+msgid "Are you sure?"
+msgstr ""
+
+#: templates/reset.html:3 templates/reset.txt:2
+msgid "Please confirm that you'd like to reset the password for %(email)s."
+msgstr ""
+
+#: templates/reset.html:4
+msgid "Reset password"
+msgstr ""
+
+#: templates/reset.html:5 templates/reset.txt:4 templates/unlock.html:4
+#: templates/unlock.txt:3 templates/verify.html:5 templates/verify.txt:4
+msgid ""
+"This is an automated email; if you received it in error, no action is "
+"required."
+msgstr ""
+
+#: templates/reset.html:6 templates/unlock.html:5 templates/verify.html:6
+msgid ""
+"For more information, please visit <a href='https://support.mozilla."
+"org'>Mozilla Support</a>"
+msgstr ""
+
+#: templates/reset.txt:3
+msgid "Reset password:"
+msgstr ""
+
+#: templates/reset.txt:5 templates/unlock.txt:4 templates/verify.txt:5
+msgid "For more information, please visit https://support.mozilla.org"
+msgstr ""
+
+#: templates/unlock.html:2 templates/unlock.txt:1
+msgid ""
+"For security reasons your Firefox Account was put on lockdown. To perform "
+"account-level activities, please click the link to re-verify your account "
+"now."
+msgstr ""
+
+#: templates/unlock.html:3
+msgid "Verify account"
+msgstr ""
+
+#: templates/unlock.txt:2
+msgid "Verify account:"
+msgstr ""
+
+#: templates/verify.html:2 templates/verify.txt:1
+msgid "Almost there"
+msgstr ""
+
+#: templates/verify.html:3 templates/verify.txt:2
+msgid "%(email)s, you're one click away from verifying your Firefox Account."
+msgstr ""
+
+#: templates/verify.html:4
+msgid "Verify"
+msgstr ""
+
+#: templates/verify.txt:3
+msgid "Verify:"
 msgstr ""

--- a/locale/gd/LC_MESSAGES/server.po
+++ b/locale/gd/LC_MESSAGES/server.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-02-20 19:15+0000\n"
+"POT-Creation-Date: 2015-02-25 18:58+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "Language: \n"
@@ -15,7 +15,8 @@ msgstr ""
 #: server/templates/pages/src/503.html:1
 #: server/templates/pages/src/index.html:1
 #: server/templates/pages/src/privacy.html:1
-#: server/templates/pages/src/terms.html:1
+#: server/templates/pages/src/terms.html:1 templates/reset.html:1
+#: templates/unlock.html:1 templates/verify.html:1
 msgid "Firefox Accounts"
 msgstr ""
 
@@ -87,4 +88,68 @@ msgstr ""
 #: server/templates/pages/src/terms.html:2
 #: server/templates/pages/src/terms.html:5
 msgid "Terms of Service"
+msgstr ""
+
+#: templates/reset.html:2 templates/reset.txt:1
+msgid "Are you sure?"
+msgstr ""
+
+#: templates/reset.html:3 templates/reset.txt:2
+msgid "Please confirm that you'd like to reset the password for %(email)s."
+msgstr ""
+
+#: templates/reset.html:4
+msgid "Reset password"
+msgstr ""
+
+#: templates/reset.html:5 templates/reset.txt:4 templates/unlock.html:4
+#: templates/unlock.txt:3 templates/verify.html:5 templates/verify.txt:4
+msgid ""
+"This is an automated email; if you received it in error, no action is "
+"required."
+msgstr ""
+
+#: templates/reset.html:6 templates/unlock.html:5 templates/verify.html:6
+msgid ""
+"For more information, please visit <a href='https://support.mozilla."
+"org'>Mozilla Support</a>"
+msgstr ""
+
+#: templates/reset.txt:3
+msgid "Reset password:"
+msgstr ""
+
+#: templates/reset.txt:5 templates/unlock.txt:4 templates/verify.txt:5
+msgid "For more information, please visit https://support.mozilla.org"
+msgstr ""
+
+#: templates/unlock.html:2 templates/unlock.txt:1
+msgid ""
+"For security reasons your Firefox Account was put on lockdown. To perform "
+"account-level activities, please click the link to re-verify your account "
+"now."
+msgstr ""
+
+#: templates/unlock.html:3
+msgid "Verify account"
+msgstr ""
+
+#: templates/unlock.txt:2
+msgid "Verify account:"
+msgstr ""
+
+#: templates/verify.html:2 templates/verify.txt:1
+msgid "Almost there"
+msgstr ""
+
+#: templates/verify.html:3 templates/verify.txt:2
+msgid "%(email)s, you're one click away from verifying your Firefox Account."
+msgstr ""
+
+#: templates/verify.html:4
+msgid "Verify"
+msgstr ""
+
+#: templates/verify.txt:3
+msgid "Verify:"
 msgstr ""

--- a/locale/gl/LC_MESSAGES/server.po
+++ b/locale/gl/LC_MESSAGES/server.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-02-20 19:15+0000\n"
+"POT-Creation-Date: 2015-02-25 18:58+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "Language: \n"
@@ -15,7 +15,8 @@ msgstr ""
 #: server/templates/pages/src/503.html:1
 #: server/templates/pages/src/index.html:1
 #: server/templates/pages/src/privacy.html:1
-#: server/templates/pages/src/terms.html:1
+#: server/templates/pages/src/terms.html:1 templates/reset.html:1
+#: templates/unlock.html:1 templates/verify.html:1
 msgid "Firefox Accounts"
 msgstr "Contas Firefox"
 
@@ -89,36 +90,74 @@ msgstr "Servizos na nube do Firefox"
 msgid "Terms of Service"
 msgstr "Termos do servizo"
 
-#~ msgid "Are you sure?"
-#~ msgstr "Está seguro?"
+#: templates/reset.html:2 templates/reset.txt:1
+msgid "Are you sure?"
+msgstr "Está seguro?"
 
-#~ msgid "Please confirm that you'd like to reset the password for %(email)s."
-#~ msgstr "Confirma que quere restabelecer o contrasinal de %(email)s."
+#: templates/reset.html:3 templates/reset.txt:2
+msgid "Please confirm that you'd like to reset the password for %(email)s."
+msgstr "Confirma que quere restabelecer o contrasinal de %(email)s."
 
-#~ msgid "Reset password"
-#~ msgstr "Restabelecer contrasinal"
+#: templates/reset.html:4
+msgid "Reset password"
+msgstr "Restabelecer contrasinal"
 
-#~ msgid ""
-#~ "For more information, please visit <a href='https://support.mozilla."
-#~ "org'>Mozilla Support</a>"
-#~ msgstr ""
-#~ "Para obter máis información, visite a páxina de <a href='https://support."
-#~ "mozilla.org'>asistencia de Mozilla</a>"
+#: templates/reset.html:5 templates/reset.txt:4 templates/unlock.html:4
+#: templates/unlock.txt:3 templates/verify.html:5 templates/verify.txt:4
+msgid ""
+"This is an automated email; if you received it in error, no action is "
+"required."
+msgstr ""
 
-#~ msgid "Reset password:"
-#~ msgstr "Restabelecer contrasinal:"
+#: templates/reset.html:6 templates/unlock.html:5 templates/verify.html:6
+msgid ""
+"For more information, please visit <a href='https://support.mozilla."
+"org'>Mozilla Support</a>"
+msgstr ""
+"Para obter máis información, visite a páxina de <a href='https://support."
+"mozilla.org'>asistencia de Mozilla</a>"
 
-#~ msgid "For more information, please visit https://support.mozilla.org"
-#~ msgstr "Para obter máis información, visite https://support.mozilla.org"
+#: templates/reset.txt:3
+msgid "Reset password:"
+msgstr "Restabelecer contrasinal:"
+
+#: templates/reset.txt:5 templates/unlock.txt:4 templates/verify.txt:5
+msgid "For more information, please visit https://support.mozilla.org"
+msgstr "Para obter máis información, visite https://support.mozilla.org"
+
+#: templates/unlock.html:2 templates/unlock.txt:1
+msgid ""
+"For security reasons your Firefox Account was put on lockdown. To perform "
+"account-level activities, please click the link to re-verify your account "
+"now."
+msgstr ""
+
+#: templates/unlock.html:3
+msgid "Verify account"
+msgstr ""
+
+#: templates/unlock.txt:2
+msgid "Verify account:"
+msgstr ""
+
+#: templates/verify.html:2 templates/verify.txt:1
+msgid "Almost there"
+msgstr ""
+
+#: templates/verify.html:3 templates/verify.txt:2
+msgid "%(email)s, you're one click away from verifying your Firefox Account."
+msgstr ""
+
+#: templates/verify.html:4
+msgid "Verify"
+msgstr "Comprobar"
+
+#: templates/verify.txt:3
+msgid "Verify:"
+msgstr "Comprobar:"
 
 #~ msgid "Congratulations!"
 #~ msgstr "Parabéns!"
-
-#~ msgid "Verify"
-#~ msgstr "Comprobar"
-
-#~ msgid "Verify:"
-#~ msgstr "Comprobar:"
 
 #~ msgid "Verify your account"
 #~ msgstr "Comprobar a súa conta"

--- a/locale/gu/LC_MESSAGES/server.po
+++ b/locale/gu/LC_MESSAGES/server.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-02-20 19:15+0000\n"
+"POT-Creation-Date: 2015-02-25 18:58+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "Language: \n"
@@ -15,7 +15,8 @@ msgstr ""
 #: server/templates/pages/src/503.html:1
 #: server/templates/pages/src/index.html:1
 #: server/templates/pages/src/privacy.html:1
-#: server/templates/pages/src/terms.html:1
+#: server/templates/pages/src/terms.html:1 templates/reset.html:1
+#: templates/unlock.html:1 templates/verify.html:1
 msgid "Firefox Accounts"
 msgstr ""
 
@@ -87,4 +88,68 @@ msgstr ""
 #: server/templates/pages/src/terms.html:2
 #: server/templates/pages/src/terms.html:5
 msgid "Terms of Service"
+msgstr ""
+
+#: templates/reset.html:2 templates/reset.txt:1
+msgid "Are you sure?"
+msgstr ""
+
+#: templates/reset.html:3 templates/reset.txt:2
+msgid "Please confirm that you'd like to reset the password for %(email)s."
+msgstr ""
+
+#: templates/reset.html:4
+msgid "Reset password"
+msgstr ""
+
+#: templates/reset.html:5 templates/reset.txt:4 templates/unlock.html:4
+#: templates/unlock.txt:3 templates/verify.html:5 templates/verify.txt:4
+msgid ""
+"This is an automated email; if you received it in error, no action is "
+"required."
+msgstr ""
+
+#: templates/reset.html:6 templates/unlock.html:5 templates/verify.html:6
+msgid ""
+"For more information, please visit <a href='https://support.mozilla."
+"org'>Mozilla Support</a>"
+msgstr ""
+
+#: templates/reset.txt:3
+msgid "Reset password:"
+msgstr ""
+
+#: templates/reset.txt:5 templates/unlock.txt:4 templates/verify.txt:5
+msgid "For more information, please visit https://support.mozilla.org"
+msgstr ""
+
+#: templates/unlock.html:2 templates/unlock.txt:1
+msgid ""
+"For security reasons your Firefox Account was put on lockdown. To perform "
+"account-level activities, please click the link to re-verify your account "
+"now."
+msgstr ""
+
+#: templates/unlock.html:3
+msgid "Verify account"
+msgstr ""
+
+#: templates/unlock.txt:2
+msgid "Verify account:"
+msgstr ""
+
+#: templates/verify.html:2 templates/verify.txt:1
+msgid "Almost there"
+msgstr ""
+
+#: templates/verify.html:3 templates/verify.txt:2
+msgid "%(email)s, you're one click away from verifying your Firefox Account."
+msgstr ""
+
+#: templates/verify.html:4
+msgid "Verify"
+msgstr ""
+
+#: templates/verify.txt:3
+msgid "Verify:"
 msgstr ""

--- a/locale/gu_IN/LC_MESSAGES/server.po
+++ b/locale/gu_IN/LC_MESSAGES/server.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-02-20 19:15+0000\n"
+"POT-Creation-Date: 2015-02-25 18:58+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,7 +17,8 @@ msgstr ""
 #: server/templates/pages/src/503.html:1
 #: server/templates/pages/src/index.html:1
 #: server/templates/pages/src/privacy.html:1
-#: server/templates/pages/src/terms.html:1
+#: server/templates/pages/src/terms.html:1 templates/reset.html:1
+#: templates/unlock.html:1 templates/verify.html:1
 msgid "Firefox Accounts"
 msgstr ""
 
@@ -89,4 +90,68 @@ msgstr ""
 #: server/templates/pages/src/terms.html:2
 #: server/templates/pages/src/terms.html:5
 msgid "Terms of Service"
+msgstr ""
+
+#: templates/reset.html:2 templates/reset.txt:1
+msgid "Are you sure?"
+msgstr ""
+
+#: templates/reset.html:3 templates/reset.txt:2
+msgid "Please confirm that you'd like to reset the password for %(email)s."
+msgstr ""
+
+#: templates/reset.html:4
+msgid "Reset password"
+msgstr ""
+
+#: templates/reset.html:5 templates/reset.txt:4 templates/unlock.html:4
+#: templates/unlock.txt:3 templates/verify.html:5 templates/verify.txt:4
+msgid ""
+"This is an automated email; if you received it in error, no action is "
+"required."
+msgstr ""
+
+#: templates/reset.html:6 templates/unlock.html:5 templates/verify.html:6
+msgid ""
+"For more information, please visit <a href='https://support.mozilla."
+"org'>Mozilla Support</a>"
+msgstr ""
+
+#: templates/reset.txt:3
+msgid "Reset password:"
+msgstr ""
+
+#: templates/reset.txt:5 templates/unlock.txt:4 templates/verify.txt:5
+msgid "For more information, please visit https://support.mozilla.org"
+msgstr ""
+
+#: templates/unlock.html:2 templates/unlock.txt:1
+msgid ""
+"For security reasons your Firefox Account was put on lockdown. To perform "
+"account-level activities, please click the link to re-verify your account "
+"now."
+msgstr ""
+
+#: templates/unlock.html:3
+msgid "Verify account"
+msgstr ""
+
+#: templates/unlock.txt:2
+msgid "Verify account:"
+msgstr ""
+
+#: templates/verify.html:2 templates/verify.txt:1
+msgid "Almost there"
+msgstr ""
+
+#: templates/verify.html:3 templates/verify.txt:2
+msgid "%(email)s, you're one click away from verifying your Firefox Account."
+msgstr ""
+
+#: templates/verify.html:4
+msgid "Verify"
+msgstr ""
+
+#: templates/verify.txt:3
+msgid "Verify:"
 msgstr ""

--- a/locale/he/LC_MESSAGES/server.po
+++ b/locale/he/LC_MESSAGES/server.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-02-20 19:15+0000\n"
+"POT-Creation-Date: 2015-02-25 18:58+0000\n"
 "PO-Revision-Date: 2014-03-13 13:05+0000\n"
 "Last-Translator: Tomer <tomer@gmx.net>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -19,7 +19,8 @@ msgstr ""
 #: server/templates/pages/src/503.html:1
 #: server/templates/pages/src/index.html:1
 #: server/templates/pages/src/privacy.html:1
-#: server/templates/pages/src/terms.html:1
+#: server/templates/pages/src/terms.html:1 templates/reset.html:1
+#: templates/unlock.html:1 templates/verify.html:1
 msgid "Firefox Accounts"
 msgstr "Firefox Accounts"
 
@@ -95,34 +96,74 @@ msgstr "Firefox Accounts"
 msgid "Terms of Service"
 msgstr ""
 
+#: templates/reset.html:2 templates/reset.txt:1
+msgid "Are you sure?"
+msgstr ""
+
+#: templates/reset.html:3 templates/reset.txt:2
 #, fuzzy
-#~ msgid "Please confirm that you'd like to reset the password for %(email)s."
-#~ msgstr "התקבלה בקשה לאפס ססמה עבור %(email)s."
+msgid "Please confirm that you'd like to reset the password for %(email)s."
+msgstr "התקבלה בקשה לאפס ססמה עבור %(email)s."
 
-#~ msgid "Reset password"
-#~ msgstr "איפוס ססמה"
+#: templates/reset.html:4
+msgid "Reset password"
+msgstr "איפוס ססמה"
 
+#: templates/reset.html:5 templates/reset.txt:4 templates/unlock.html:4
+#: templates/unlock.txt:3 templates/verify.html:5 templates/verify.txt:4
 #, fuzzy
-#~ msgid ""
-#~ "This is an automated email; if you received it in error, no action is "
-#~ "required."
-#~ msgstr "אם הודעה זו הגיעה אליך בטעות, אין צורך בשום פעולה מצידך. "
+msgid ""
+"This is an automated email; if you received it in error, no action is "
+"required."
+msgstr "אם הודעה זו הגיעה אליך בטעות, אין צורך בשום פעולה מצידך. "
 
-#~ msgid "Reset password:"
-#~ msgstr "איפוס ססמה:"
+#: templates/reset.html:6 templates/unlock.html:5 templates/verify.html:6
+msgid ""
+"For more information, please visit <a href='https://support.mozilla."
+"org'>Mozilla Support</a>"
+msgstr ""
 
+#: templates/reset.txt:3
+msgid "Reset password:"
+msgstr "איפוס ססמה:"
+
+#: templates/reset.txt:5 templates/unlock.txt:4 templates/verify.txt:5
+msgid "For more information, please visit https://support.mozilla.org"
+msgstr ""
+
+#: templates/unlock.html:2 templates/unlock.txt:1
+msgid ""
+"For security reasons your Firefox Account was put on lockdown. To perform "
+"account-level activities, please click the link to re-verify your account "
+"now."
+msgstr ""
+
+#: templates/unlock.html:3
+msgid "Verify account"
+msgstr ""
+
+#: templates/unlock.txt:2
+msgid "Verify account:"
+msgstr ""
+
+#: templates/verify.html:2 templates/verify.txt:1
+msgid "Almost there"
+msgstr ""
+
+#: templates/verify.html:3 templates/verify.txt:2
 #, fuzzy
-#~ msgid ""
-#~ "%(email)s, you're one click away from verifying your Firefox Account."
-#~ msgstr ""
-#~ "ברכותינו! %(email)s, הנך במרחק של שניות ספורות מאימות החשבון שלך ב־"
-#~ "Firefox Account."
+msgid "%(email)s, you're one click away from verifying your Firefox Account."
+msgstr ""
+"ברכותינו! %(email)s, הנך במרחק של שניות ספורות מאימות החשבון שלך ב־Firefox "
+"Account."
 
-#~ msgid "Verify"
-#~ msgstr "אימות"
+#: templates/verify.html:4
+msgid "Verify"
+msgstr "אימות"
 
-#~ msgid "Verify:"
-#~ msgstr "אימות:"
+#: templates/verify.txt:3
+msgid "Verify:"
+msgstr "אימות:"
 
 #, fuzzy
 #~ msgid "Verify your account"

--- a/locale/hi_IN/LC_MESSAGES/server.po
+++ b/locale/hi_IN/LC_MESSAGES/server.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-02-20 19:15+0000\n"
+"POT-Creation-Date: 2015-02-25 18:58+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,7 +17,8 @@ msgstr ""
 #: server/templates/pages/src/503.html:1
 #: server/templates/pages/src/index.html:1
 #: server/templates/pages/src/privacy.html:1
-#: server/templates/pages/src/terms.html:1
+#: server/templates/pages/src/terms.html:1 templates/reset.html:1
+#: templates/unlock.html:1 templates/verify.html:1
 msgid "Firefox Accounts"
 msgstr ""
 
@@ -89,4 +90,68 @@ msgstr ""
 #: server/templates/pages/src/terms.html:2
 #: server/templates/pages/src/terms.html:5
 msgid "Terms of Service"
+msgstr ""
+
+#: templates/reset.html:2 templates/reset.txt:1
+msgid "Are you sure?"
+msgstr ""
+
+#: templates/reset.html:3 templates/reset.txt:2
+msgid "Please confirm that you'd like to reset the password for %(email)s."
+msgstr ""
+
+#: templates/reset.html:4
+msgid "Reset password"
+msgstr ""
+
+#: templates/reset.html:5 templates/reset.txt:4 templates/unlock.html:4
+#: templates/unlock.txt:3 templates/verify.html:5 templates/verify.txt:4
+msgid ""
+"This is an automated email; if you received it in error, no action is "
+"required."
+msgstr ""
+
+#: templates/reset.html:6 templates/unlock.html:5 templates/verify.html:6
+msgid ""
+"For more information, please visit <a href='https://support.mozilla."
+"org'>Mozilla Support</a>"
+msgstr ""
+
+#: templates/reset.txt:3
+msgid "Reset password:"
+msgstr ""
+
+#: templates/reset.txt:5 templates/unlock.txt:4 templates/verify.txt:5
+msgid "For more information, please visit https://support.mozilla.org"
+msgstr ""
+
+#: templates/unlock.html:2 templates/unlock.txt:1
+msgid ""
+"For security reasons your Firefox Account was put on lockdown. To perform "
+"account-level activities, please click the link to re-verify your account "
+"now."
+msgstr ""
+
+#: templates/unlock.html:3
+msgid "Verify account"
+msgstr ""
+
+#: templates/unlock.txt:2
+msgid "Verify account:"
+msgstr ""
+
+#: templates/verify.html:2 templates/verify.txt:1
+msgid "Almost there"
+msgstr ""
+
+#: templates/verify.html:3 templates/verify.txt:2
+msgid "%(email)s, you're one click away from verifying your Firefox Account."
+msgstr ""
+
+#: templates/verify.html:4
+msgid "Verify"
+msgstr ""
+
+#: templates/verify.txt:3
+msgid "Verify:"
 msgstr ""

--- a/locale/hr/LC_MESSAGES/server.po
+++ b/locale/hr/LC_MESSAGES/server.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-02-20 19:15+0000\n"
+"POT-Creation-Date: 2015-02-25 18:58+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "Language: \n"
@@ -15,7 +15,8 @@ msgstr ""
 #: server/templates/pages/src/503.html:1
 #: server/templates/pages/src/index.html:1
 #: server/templates/pages/src/privacy.html:1
-#: server/templates/pages/src/terms.html:1
+#: server/templates/pages/src/terms.html:1 templates/reset.html:1
+#: templates/unlock.html:1 templates/verify.html:1
 msgid "Firefox Accounts"
 msgstr ""
 
@@ -87,4 +88,68 @@ msgstr ""
 #: server/templates/pages/src/terms.html:2
 #: server/templates/pages/src/terms.html:5
 msgid "Terms of Service"
+msgstr ""
+
+#: templates/reset.html:2 templates/reset.txt:1
+msgid "Are you sure?"
+msgstr ""
+
+#: templates/reset.html:3 templates/reset.txt:2
+msgid "Please confirm that you'd like to reset the password for %(email)s."
+msgstr ""
+
+#: templates/reset.html:4
+msgid "Reset password"
+msgstr ""
+
+#: templates/reset.html:5 templates/reset.txt:4 templates/unlock.html:4
+#: templates/unlock.txt:3 templates/verify.html:5 templates/verify.txt:4
+msgid ""
+"This is an automated email; if you received it in error, no action is "
+"required."
+msgstr ""
+
+#: templates/reset.html:6 templates/unlock.html:5 templates/verify.html:6
+msgid ""
+"For more information, please visit <a href='https://support.mozilla."
+"org'>Mozilla Support</a>"
+msgstr ""
+
+#: templates/reset.txt:3
+msgid "Reset password:"
+msgstr ""
+
+#: templates/reset.txt:5 templates/unlock.txt:4 templates/verify.txt:5
+msgid "For more information, please visit https://support.mozilla.org"
+msgstr ""
+
+#: templates/unlock.html:2 templates/unlock.txt:1
+msgid ""
+"For security reasons your Firefox Account was put on lockdown. To perform "
+"account-level activities, please click the link to re-verify your account "
+"now."
+msgstr ""
+
+#: templates/unlock.html:3
+msgid "Verify account"
+msgstr ""
+
+#: templates/unlock.txt:2
+msgid "Verify account:"
+msgstr ""
+
+#: templates/verify.html:2 templates/verify.txt:1
+msgid "Almost there"
+msgstr ""
+
+#: templates/verify.html:3 templates/verify.txt:2
+msgid "%(email)s, you're one click away from verifying your Firefox Account."
+msgstr ""
+
+#: templates/verify.html:4
+msgid "Verify"
+msgstr ""
+
+#: templates/verify.txt:3
+msgid "Verify:"
 msgstr ""

--- a/locale/hsb/LC_MESSAGES/server.po
+++ b/locale/hsb/LC_MESSAGES/server.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2014-11-10 18:39+0000\n"
+"POT-Creation-Date: 2015-02-25 18:58+0000\n"
 "PO-Revision-Date: 2014-10-12 16:32+0000\n"
 "Last-Translator: milupo <milupo@sorbzilla.de>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -15,14 +15,19 @@ msgstr ""
 "X-Generator: Pootle 2.5.0\n"
 "X-POOTLE-MTIME: 1413131578.0\n"
 
-#: server/templates/pages/src/404.html:1 server/templates/pages/src/500.html:1
+#: server/templates/pages/src/400.html:1 server/templates/pages/src/404.html:1
+#: server/templates/pages/src/500.html:1 server/templates/pages/src/502.html:1
 #: server/templates/pages/src/503.html:1
 #: server/templates/pages/src/index.html:1
 #: server/templates/pages/src/privacy.html:1
-#: server/templates/pages/src/terms.html:1 server/templates/email/reset.html:1
-#: server/templates/email/verify.html:1
+#: server/templates/pages/src/terms.html:1 templates/reset.html:1
+#: templates/unlock.html:1 templates/verify.html:1
 msgid "Firefox Accounts"
 msgstr "Firefox Accounts"
+
+#: server/templates/pages/src/400.html:2
+msgid "Bad Request"
+msgstr ""
 
 #: server/templates/pages/src/404.html:2
 msgid "Page not found"
@@ -37,7 +42,7 @@ msgstr ""
 "porjedźimy skóncowane wotkazy."
 
 #: server/templates/pages/src/404.html:4 server/templates/pages/src/500.html:4
-#: server/templates/pages/src/503.html:4
+#: server/templates/pages/src/502.html:4 server/templates/pages/src/503.html:4
 msgid "Home"
 msgstr "Startowa strona"
 
@@ -45,13 +50,17 @@ msgstr "Startowa strona"
 msgid "500 Error"
 msgstr "Zmylk 500"
 
-#: server/templates/pages/src/500.html:3
+#: server/templates/pages/src/500.html:3 server/templates/pages/src/502.html:3
 msgid ""
 "Oh dear, something went wrong there. We've been notified and will get "
 "working on a fix."
 msgstr ""
 "Božo mój, něšto je so nimokuliło. Smy so informowali a damy so do "
 "wotstronjenja problema."
+
+#: server/templates/pages/src/502.html:2
+msgid "502 Error"
+msgstr ""
 
 #: server/templates/pages/src/503.html:2
 msgid "Server busy, try again soon"
@@ -95,20 +104,20 @@ msgstr "Mróčelowe słužby Firefox"
 msgid "Terms of Service"
 msgstr "Wužiwanske wuměnenja"
 
-#: server/templates/email/reset.html:2 server/templates/email/reset.txt:1
+#: templates/reset.html:2 templates/reset.txt:1
 msgid "Are you sure?"
 msgstr "Sće sej wěsty?"
 
-#: server/templates/email/reset.html:3 server/templates/email/reset.txt:2
+#: templates/reset.html:3 templates/reset.txt:2
 msgid "Please confirm that you'd like to reset the password for %(email)s."
 msgstr "Prošu wubkrućće, zo chceće hesło za %(email)s wróćo stajić."
 
-#: server/templates/email/reset.html:4
+#: templates/reset.html:4
 msgid "Reset password"
 msgstr "Hesło wróćo stajić"
 
-#: server/templates/email/reset.html:5 server/templates/email/reset.txt:4
-#: server/templates/email/verify.html:5 server/templates/email/verify.txt:4
+#: templates/reset.html:5 templates/reset.txt:4 templates/unlock.html:4
+#: templates/unlock.txt:3 templates/verify.html:5 templates/verify.txt:4
 msgid ""
 "This is an automated email; if you received it in error, no action is "
 "required."
@@ -116,7 +125,7 @@ msgstr ""
 "To je awtomatizowana e-mejlka; jeli sće ju zmylnje dóstał, njetrjebaće ničo "
 "činić."
 
-#: server/templates/email/reset.html:6 server/templates/email/verify.html:6
+#: templates/reset.html:6 templates/unlock.html:5 templates/verify.html:6
 msgid ""
 "For more information, please visit <a href='https://support.mozilla."
 "org'>Mozilla Support</a>"
@@ -124,39 +133,55 @@ msgstr ""
 "Za dalše informacije wopytajće prošu <a href='https://support.mozilla."
 "org'>Pomoc Mozilla</a>"
 
-#: server/templates/email/reset.txt:3
+#: templates/reset.txt:3
 msgid "Reset password:"
 msgstr "Hesło wróćo stajić:"
 
-#: server/templates/email/reset.txt:5 server/templates/email/verify.txt:5
+#: templates/reset.txt:5 templates/unlock.txt:4 templates/verify.txt:5
 msgid "For more information, please visit https://support.mozilla.org"
 msgstr "Za dalše informacije wopytajće prošu https://support.mozilla.org"
 
-#: server/templates/email/verify.html:2 server/templates/email/verify.txt:1
-msgid "Congratulations!"
-msgstr "Zbožopřeće!"
+#: templates/unlock.html:2 templates/unlock.txt:1
+msgid ""
+"For security reasons your Firefox Account was put on lockdown. To perform "
+"account-level activities, please click the link to re-verify your account "
+"now."
+msgstr ""
 
-#: server/templates/email/verify.html:3 server/templates/email/verify.txt:2
+#: templates/unlock.html:3
+msgid "Verify account"
+msgstr ""
+
+#: templates/unlock.txt:2
+msgid "Verify account:"
+msgstr ""
+
+#: templates/verify.html:2 templates/verify.txt:1
+msgid "Almost there"
+msgstr ""
+
+#: templates/verify.html:3 templates/verify.txt:2
 msgid "%(email)s, you're one click away from verifying your Firefox Account."
 msgstr ""
 "%(email)s, sće jenož jedne kliknjenje wot wobkrućenja swojeho konta Firefox "
 "zdaleny."
 
-#: server/templates/email/verify.html:4
+#: templates/verify.html:4
 msgid "Verify"
 msgstr "Wobkrućić"
 
-#: server/templates/email/verify.txt:3
+#: templates/verify.txt:3
 msgid "Verify:"
 msgstr "Wobkrućić:"
 
-#: server/lib/templates.js:63
-msgid "Verify your account"
-msgstr "Wobkrućće swoje konto"
+#~ msgid "Congratulations!"
+#~ msgstr "Zbožopřeće!"
 
-#: server/lib/templates.js:68
-msgid "Reset your password"
-msgstr "Stajće swoje hesło wróćo"
+#~ msgid "Verify your account"
+#~ msgstr "Wobkrućće swoje konto"
+
+#~ msgid "Reset your password"
+#~ msgstr "Stajće swoje hesło wróćo"
 
 #~ msgid "System unavailable, try again soon"
 #~ msgstr "System k dispoziciji njesteji, spytajće za krótki čas hišće raz"

--- a/locale/ht/LC_MESSAGES/server.po
+++ b/locale/ht/LC_MESSAGES/server.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-02-20 19:15+0000\n"
+"POT-Creation-Date: 2015-02-25 18:58+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "Language: \n"
@@ -15,7 +15,8 @@ msgstr ""
 #: server/templates/pages/src/503.html:1
 #: server/templates/pages/src/index.html:1
 #: server/templates/pages/src/privacy.html:1
-#: server/templates/pages/src/terms.html:1
+#: server/templates/pages/src/terms.html:1 templates/reset.html:1
+#: templates/unlock.html:1 templates/verify.html:1
 msgid "Firefox Accounts"
 msgstr ""
 
@@ -87,4 +88,68 @@ msgstr ""
 #: server/templates/pages/src/terms.html:2
 #: server/templates/pages/src/terms.html:5
 msgid "Terms of Service"
+msgstr ""
+
+#: templates/reset.html:2 templates/reset.txt:1
+msgid "Are you sure?"
+msgstr ""
+
+#: templates/reset.html:3 templates/reset.txt:2
+msgid "Please confirm that you'd like to reset the password for %(email)s."
+msgstr ""
+
+#: templates/reset.html:4
+msgid "Reset password"
+msgstr ""
+
+#: templates/reset.html:5 templates/reset.txt:4 templates/unlock.html:4
+#: templates/unlock.txt:3 templates/verify.html:5 templates/verify.txt:4
+msgid ""
+"This is an automated email; if you received it in error, no action is "
+"required."
+msgstr ""
+
+#: templates/reset.html:6 templates/unlock.html:5 templates/verify.html:6
+msgid ""
+"For more information, please visit <a href='https://support.mozilla."
+"org'>Mozilla Support</a>"
+msgstr ""
+
+#: templates/reset.txt:3
+msgid "Reset password:"
+msgstr ""
+
+#: templates/reset.txt:5 templates/unlock.txt:4 templates/verify.txt:5
+msgid "For more information, please visit https://support.mozilla.org"
+msgstr ""
+
+#: templates/unlock.html:2 templates/unlock.txt:1
+msgid ""
+"For security reasons your Firefox Account was put on lockdown. To perform "
+"account-level activities, please click the link to re-verify your account "
+"now."
+msgstr ""
+
+#: templates/unlock.html:3
+msgid "Verify account"
+msgstr ""
+
+#: templates/unlock.txt:2
+msgid "Verify account:"
+msgstr ""
+
+#: templates/verify.html:2 templates/verify.txt:1
+msgid "Almost there"
+msgstr ""
+
+#: templates/verify.html:3 templates/verify.txt:2
+msgid "%(email)s, you're one click away from verifying your Firefox Account."
+msgstr ""
+
+#: templates/verify.html:4
+msgid "Verify"
+msgstr ""
+
+#: templates/verify.txt:3
+msgid "Verify:"
 msgstr ""

--- a/locale/hu/LC_MESSAGES/server.po
+++ b/locale/hu/LC_MESSAGES/server.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-02-20 19:15+0000\n"
+"POT-Creation-Date: 2015-02-25 18:58+0000\n"
 "PO-Revision-Date: 2014-10-13 08:16+0000\n"
 "Last-Translator: Gábor <kelemeng@ubuntu.com>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -19,7 +19,8 @@ msgstr ""
 #: server/templates/pages/src/503.html:1
 #: server/templates/pages/src/index.html:1
 #: server/templates/pages/src/privacy.html:1
-#: server/templates/pages/src/terms.html:1
+#: server/templates/pages/src/terms.html:1 templates/reset.html:1
+#: templates/unlock.html:1 templates/verify.html:1
 msgid "Firefox Accounts"
 msgstr "Firefox fiókok"
 
@@ -101,48 +102,77 @@ msgstr "Firefox felhő szolgáltatások"
 msgid "Terms of Service"
 msgstr "Felhasználási feltételek"
 
-#~ msgid "Are you sure?"
-#~ msgstr "Biztos benne?"
+#: templates/reset.html:2 templates/reset.txt:1
+msgid "Are you sure?"
+msgstr "Biztos benne?"
 
-#~ msgid "Please confirm that you'd like to reset the password for %(email)s."
-#~ msgstr "Erősítse meg, hogy szeretné visszaállítani %(email)s jelszavát."
+#: templates/reset.html:3 templates/reset.txt:2
+msgid "Please confirm that you'd like to reset the password for %(email)s."
+msgstr "Erősítse meg, hogy szeretné visszaállítani %(email)s jelszavát."
 
-#~ msgid "Reset password"
-#~ msgstr "Jelszó visszaállítása"
+#: templates/reset.html:4
+msgid "Reset password"
+msgstr "Jelszó visszaállítása"
 
-#~ msgid ""
-#~ "This is an automated email; if you received it in error, no action is "
-#~ "required."
-#~ msgstr ""
-#~ "Ez egy automatikus üzenet, ha úgy véli tévedésből kapta, akkor nincs "
-#~ "teendője."
+#: templates/reset.html:5 templates/reset.txt:4 templates/unlock.html:4
+#: templates/unlock.txt:3 templates/verify.html:5 templates/verify.txt:4
+msgid ""
+"This is an automated email; if you received it in error, no action is "
+"required."
+msgstr ""
+"Ez egy automatikus üzenet, ha úgy véli tévedésből kapta, akkor nincs "
+"teendője."
 
-#~ msgid ""
-#~ "For more information, please visit <a href='https://support.mozilla."
-#~ "org'>Mozilla Support</a>"
-#~ msgstr ""
-#~ "További információkért keresse fel a <a href='https://support.mozilla."
-#~ "org'>Mozilla támogatást</a>"
+#: templates/reset.html:6 templates/unlock.html:5 templates/verify.html:6
+msgid ""
+"For more information, please visit <a href='https://support.mozilla."
+"org'>Mozilla Support</a>"
+msgstr ""
+"További információkért keresse fel a <a href='https://support.mozilla."
+"org'>Mozilla támogatást</a>"
 
-#~ msgid "Reset password:"
-#~ msgstr "Jelszó visszaállítása:"
+#: templates/reset.txt:3
+msgid "Reset password:"
+msgstr "Jelszó visszaállítása:"
 
-#~ msgid "For more information, please visit https://support.mozilla.org"
-#~ msgstr ""
-#~ "További információkért keresse fel a https://support.mozilla.org oldalt"
+#: templates/reset.txt:5 templates/unlock.txt:4 templates/verify.txt:5
+msgid "For more information, please visit https://support.mozilla.org"
+msgstr ""
+"További információkért keresse fel a https://support.mozilla.org oldalt"
+
+#: templates/unlock.html:2 templates/unlock.txt:1
+msgid ""
+"For security reasons your Firefox Account was put on lockdown. To perform "
+"account-level activities, please click the link to re-verify your account "
+"now."
+msgstr ""
+
+#: templates/unlock.html:3
+msgid "Verify account"
+msgstr ""
+
+#: templates/unlock.txt:2
+msgid "Verify account:"
+msgstr ""
+
+#: templates/verify.html:2 templates/verify.txt:1
+msgid "Almost there"
+msgstr ""
+
+#: templates/verify.html:3 templates/verify.txt:2
+msgid "%(email)s, you're one click away from verifying your Firefox Account."
+msgstr "%(email)s, Ön egy kattintásra van Firefox fiókjának ellenőrzésétől."
+
+#: templates/verify.html:4
+msgid "Verify"
+msgstr "Ellenőrzés"
+
+#: templates/verify.txt:3
+msgid "Verify:"
+msgstr "Ellenőrzés:"
 
 #~ msgid "Congratulations!"
 #~ msgstr "Gratulálunk!"
-
-#~ msgid ""
-#~ "%(email)s, you're one click away from verifying your Firefox Account."
-#~ msgstr "%(email)s, Ön egy kattintásra van Firefox fiókjának ellenőrzésétől."
-
-#~ msgid "Verify"
-#~ msgstr "Ellenőrzés"
-
-#~ msgid "Verify:"
-#~ msgstr "Ellenőrzés:"
 
 #~ msgid "Verify your account"
 #~ msgstr "Fiók ellenőrzése"

--- a/locale/hy_AM/LC_MESSAGES/server.po
+++ b/locale/hy_AM/LC_MESSAGES/server.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-02-20 19:15+0000\n"
+"POT-Creation-Date: 2015-02-25 18:58+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,7 +17,8 @@ msgstr ""
 #: server/templates/pages/src/503.html:1
 #: server/templates/pages/src/index.html:1
 #: server/templates/pages/src/privacy.html:1
-#: server/templates/pages/src/terms.html:1
+#: server/templates/pages/src/terms.html:1 templates/reset.html:1
+#: templates/unlock.html:1 templates/verify.html:1
 msgid "Firefox Accounts"
 msgstr ""
 
@@ -89,4 +90,68 @@ msgstr ""
 #: server/templates/pages/src/terms.html:2
 #: server/templates/pages/src/terms.html:5
 msgid "Terms of Service"
+msgstr ""
+
+#: templates/reset.html:2 templates/reset.txt:1
+msgid "Are you sure?"
+msgstr ""
+
+#: templates/reset.html:3 templates/reset.txt:2
+msgid "Please confirm that you'd like to reset the password for %(email)s."
+msgstr ""
+
+#: templates/reset.html:4
+msgid "Reset password"
+msgstr ""
+
+#: templates/reset.html:5 templates/reset.txt:4 templates/unlock.html:4
+#: templates/unlock.txt:3 templates/verify.html:5 templates/verify.txt:4
+msgid ""
+"This is an automated email; if you received it in error, no action is "
+"required."
+msgstr ""
+
+#: templates/reset.html:6 templates/unlock.html:5 templates/verify.html:6
+msgid ""
+"For more information, please visit <a href='https://support.mozilla."
+"org'>Mozilla Support</a>"
+msgstr ""
+
+#: templates/reset.txt:3
+msgid "Reset password:"
+msgstr ""
+
+#: templates/reset.txt:5 templates/unlock.txt:4 templates/verify.txt:5
+msgid "For more information, please visit https://support.mozilla.org"
+msgstr ""
+
+#: templates/unlock.html:2 templates/unlock.txt:1
+msgid ""
+"For security reasons your Firefox Account was put on lockdown. To perform "
+"account-level activities, please click the link to re-verify your account "
+"now."
+msgstr ""
+
+#: templates/unlock.html:3
+msgid "Verify account"
+msgstr ""
+
+#: templates/unlock.txt:2
+msgid "Verify account:"
+msgstr ""
+
+#: templates/verify.html:2 templates/verify.txt:1
+msgid "Almost there"
+msgstr ""
+
+#: templates/verify.html:3 templates/verify.txt:2
+msgid "%(email)s, you're one click away from verifying your Firefox Account."
+msgstr ""
+
+#: templates/verify.html:4
+msgid "Verify"
+msgstr ""
+
+#: templates/verify.txt:3
+msgid "Verify:"
 msgstr ""

--- a/locale/id/LC_MESSAGES/server.po
+++ b/locale/id/LC_MESSAGES/server.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-02-20 19:15+0000\n"
+"POT-Creation-Date: 2015-02-25 18:58+0000\n"
 "PO-Revision-Date: 2014-05-07 21:30+0000\n"
 "Last-Translator: Romi <romihardiyanto@gmail.com>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -19,7 +19,8 @@ msgstr ""
 #: server/templates/pages/src/503.html:1
 #: server/templates/pages/src/index.html:1
 #: server/templates/pages/src/privacy.html:1
-#: server/templates/pages/src/terms.html:1
+#: server/templates/pages/src/terms.html:1 templates/reset.html:1
+#: templates/unlock.html:1 templates/verify.html:1
 msgid "Firefox Accounts"
 msgstr "Akun Firefox"
 
@@ -100,49 +101,78 @@ msgstr "Layanan awan Firefox"
 msgid "Terms of Service"
 msgstr "Ketentuan Layanan"
 
-#~ msgid "Are you sure?"
-#~ msgstr "Yakin?"
+#: templates/reset.html:2 templates/reset.txt:1
+msgid "Are you sure?"
+msgstr "Yakin?"
 
-#~ msgid "Please confirm that you'd like to reset the password for %(email)s."
-#~ msgstr ""
-#~ "Mohon konfirmasi bahwa Anda telah meminta penyetelan ulang sandi untuk "
-#~ "%(email)s."
+#: templates/reset.html:3 templates/reset.txt:2
+msgid "Please confirm that you'd like to reset the password for %(email)s."
+msgstr ""
+"Mohon konfirmasi bahwa Anda telah meminta penyetelan ulang sandi untuk "
+"%(email)s."
 
-#~ msgid "Reset password"
-#~ msgstr "Setel ulang sandi"
+#: templates/reset.html:4
+msgid "Reset password"
+msgstr "Setel ulang sandi"
 
-#~ msgid ""
-#~ "This is an automated email; if you received it in error, no action is "
-#~ "required."
-#~ msgstr ""
-#~ "Email ini bersifat otomatis; jika menurut Anda email ini salah alamat, "
-#~ "tidak ada tindakan yang harus dilakukan."
+#: templates/reset.html:5 templates/reset.txt:4 templates/unlock.html:4
+#: templates/unlock.txt:3 templates/verify.html:5 templates/verify.txt:4
+msgid ""
+"This is an automated email; if you received it in error, no action is "
+"required."
+msgstr ""
+"Email ini bersifat otomatis; jika menurut Anda email ini salah alamat, tidak "
+"ada tindakan yang harus dilakukan."
 
-#~ msgid ""
-#~ "For more information, please visit <a href='https://support.mozilla."
-#~ "org'>Mozilla Support</a>"
-#~ msgstr ""
-#~ "Untuk informasi lebih lanjut, kunjungi <a href='https://support.mozilla."
-#~ "org'>Dukungan Mozilla</a>"
+#: templates/reset.html:6 templates/unlock.html:5 templates/verify.html:6
+msgid ""
+"For more information, please visit <a href='https://support.mozilla."
+"org'>Mozilla Support</a>"
+msgstr ""
+"Untuk informasi lebih lanjut, kunjungi <a href='https://support.mozilla."
+"org'>Dukungan Mozilla</a>"
 
-#~ msgid "Reset password:"
-#~ msgstr "Setel ulang sandi:"
+#: templates/reset.txt:3
+msgid "Reset password:"
+msgstr "Setel ulang sandi:"
 
-#~ msgid "For more information, please visit https://support.mozilla.org"
-#~ msgstr "Untuk informasi selengkapnya, kunjungi https://support.mozilla.org"
+#: templates/reset.txt:5 templates/unlock.txt:4 templates/verify.txt:5
+msgid "For more information, please visit https://support.mozilla.org"
+msgstr "Untuk informasi selengkapnya, kunjungi https://support.mozilla.org"
+
+#: templates/unlock.html:2 templates/unlock.txt:1
+msgid ""
+"For security reasons your Firefox Account was put on lockdown. To perform "
+"account-level activities, please click the link to re-verify your account "
+"now."
+msgstr ""
+
+#: templates/unlock.html:3
+msgid "Verify account"
+msgstr ""
+
+#: templates/unlock.txt:2
+msgid "Verify account:"
+msgstr ""
+
+#: templates/verify.html:2 templates/verify.txt:1
+msgid "Almost there"
+msgstr ""
+
+#: templates/verify.html:3 templates/verify.txt:2
+msgid "%(email)s, you're one click away from verifying your Firefox Account."
+msgstr "Selamat! Hanya perlu verifikasi %(email)s untuk Akun Firefox Anda."
+
+#: templates/verify.html:4
+msgid "Verify"
+msgstr "Verifikasikan"
+
+#: templates/verify.txt:3
+msgid "Verify:"
+msgstr "Verifikasikan:"
 
 #~ msgid "Congratulations!"
 #~ msgstr "Selamat!"
-
-#~ msgid ""
-#~ "%(email)s, you're one click away from verifying your Firefox Account."
-#~ msgstr "Selamat! Hanya perlu verifikasi %(email)s untuk Akun Firefox Anda."
-
-#~ msgid "Verify"
-#~ msgstr "Verifikasikan"
-
-#~ msgid "Verify:"
-#~ msgstr "Verifikasikan:"
 
 #~ msgid "Verify your account"
 #~ msgstr "Konfirmasikan akun Anda"

--- a/locale/is/LC_MESSAGES/server.po
+++ b/locale/is/LC_MESSAGES/server.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-02-20 19:15+0000\n"
+"POT-Creation-Date: 2015-02-25 18:58+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "Language: \n"
@@ -15,7 +15,8 @@ msgstr ""
 #: server/templates/pages/src/503.html:1
 #: server/templates/pages/src/index.html:1
 #: server/templates/pages/src/privacy.html:1
-#: server/templates/pages/src/terms.html:1
+#: server/templates/pages/src/terms.html:1 templates/reset.html:1
+#: templates/unlock.html:1 templates/verify.html:1
 msgid "Firefox Accounts"
 msgstr ""
 
@@ -87,4 +88,68 @@ msgstr ""
 #: server/templates/pages/src/terms.html:2
 #: server/templates/pages/src/terms.html:5
 msgid "Terms of Service"
+msgstr ""
+
+#: templates/reset.html:2 templates/reset.txt:1
+msgid "Are you sure?"
+msgstr ""
+
+#: templates/reset.html:3 templates/reset.txt:2
+msgid "Please confirm that you'd like to reset the password for %(email)s."
+msgstr ""
+
+#: templates/reset.html:4
+msgid "Reset password"
+msgstr ""
+
+#: templates/reset.html:5 templates/reset.txt:4 templates/unlock.html:4
+#: templates/unlock.txt:3 templates/verify.html:5 templates/verify.txt:4
+msgid ""
+"This is an automated email; if you received it in error, no action is "
+"required."
+msgstr ""
+
+#: templates/reset.html:6 templates/unlock.html:5 templates/verify.html:6
+msgid ""
+"For more information, please visit <a href='https://support.mozilla."
+"org'>Mozilla Support</a>"
+msgstr ""
+
+#: templates/reset.txt:3
+msgid "Reset password:"
+msgstr ""
+
+#: templates/reset.txt:5 templates/unlock.txt:4 templates/verify.txt:5
+msgid "For more information, please visit https://support.mozilla.org"
+msgstr ""
+
+#: templates/unlock.html:2 templates/unlock.txt:1
+msgid ""
+"For security reasons your Firefox Account was put on lockdown. To perform "
+"account-level activities, please click the link to re-verify your account "
+"now."
+msgstr ""
+
+#: templates/unlock.html:3
+msgid "Verify account"
+msgstr ""
+
+#: templates/unlock.txt:2
+msgid "Verify account:"
+msgstr ""
+
+#: templates/verify.html:2 templates/verify.txt:1
+msgid "Almost there"
+msgstr ""
+
+#: templates/verify.html:3 templates/verify.txt:2
+msgid "%(email)s, you're one click away from verifying your Firefox Account."
+msgstr ""
+
+#: templates/verify.html:4
+msgid "Verify"
+msgstr ""
+
+#: templates/verify.txt:3
+msgid "Verify:"
 msgstr ""

--- a/locale/it/LC_MESSAGES/server.po
+++ b/locale/it/LC_MESSAGES/server.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-02-20 19:15+0000\n"
+"POT-Creation-Date: 2015-02-25 18:58+0000\n"
 "PO-Revision-Date: 2015-02-25 16:14+0000\n"
 "Last-Translator: Sandro <gialloporpora@mozillaitalia.org>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -19,7 +19,8 @@ msgstr ""
 #: server/templates/pages/src/503.html:1
 #: server/templates/pages/src/index.html:1
 #: server/templates/pages/src/privacy.html:1
-#: server/templates/pages/src/terms.html:1
+#: server/templates/pages/src/terms.html:1 templates/reset.html:1
+#: templates/unlock.html:1 templates/verify.html:1
 msgid "Firefox Accounts"
 msgstr "Firefox Account"
 
@@ -103,50 +104,77 @@ msgstr "Servizi cloud di Firefox"
 msgid "Terms of Service"
 msgstr "Termini di servizio"
 
-#~ msgid "Are you sure?"
-#~ msgstr "Procedere con l’operazione?"
+#: templates/reset.html:2 templates/reset.txt:1
+msgid "Are you sure?"
+msgstr "Procedere con l’operazione?"
 
-#~ msgid "Please confirm that you'd like to reset the password for %(email)s."
-#~ msgstr ""
-#~ "È necessaria una conferma per reimpostare la password per %(email)s."
+#: templates/reset.html:3 templates/reset.txt:2
+msgid "Please confirm that you'd like to reset the password for %(email)s."
+msgstr "È necessaria una conferma per reimpostare la password per %(email)s."
 
-#~ msgid "Reset password"
-#~ msgstr "Reimposta la password"
+#: templates/reset.html:4
+msgid "Reset password"
+msgstr "Reimposta la password"
 
-#~ msgid ""
-#~ "This is an automated email; if you received it in error, no action is "
-#~ "required."
-#~ msgstr ""
-#~ "Questa email è stata inviata da un servizio automatico, se hai ricevuto "
-#~ "questa email per errore, puoi semplicemente ignorarla."
+#: templates/reset.html:5 templates/reset.txt:4 templates/unlock.html:4
+#: templates/unlock.txt:3 templates/verify.html:5 templates/verify.txt:4
+msgid ""
+"This is an automated email; if you received it in error, no action is "
+"required."
+msgstr ""
+"Questa email è stata inviata da un servizio automatico, se hai ricevuto "
+"questa email per errore, puoi semplicemente ignorarla."
 
-#~ msgid ""
-#~ "For more information, please visit <a href='https://support.mozilla."
-#~ "org'>Mozilla Support</a>"
-#~ msgstr ""
-#~ "Per ulteriori informazioni visita il <a href='https://support.mozilla."
-#~ "org'>sito di supporto Mozilla</a>"
+#: templates/reset.html:6 templates/unlock.html:5 templates/verify.html:6
+msgid ""
+"For more information, please visit <a href='https://support.mozilla."
+"org'>Mozilla Support</a>"
+msgstr ""
+"Per ulteriori informazioni visita il <a href='https://support.mozilla."
+"org'>sito di supporto Mozilla</a>"
 
-#~ msgid "Reset password:"
-#~ msgstr "Reimposta la password:"
+#: templates/reset.txt:3
+msgid "Reset password:"
+msgstr "Reimposta la password:"
 
-#~ msgid "For more information, please visit https://support.mozilla.org"
-#~ msgstr "Per ulteriori informazioni visita https://support.mozilla.org"
+#: templates/reset.txt:5 templates/unlock.txt:4 templates/verify.txt:5
+msgid "For more information, please visit https://support.mozilla.org"
+msgstr "Per ulteriori informazioni visita https://support.mozilla.org"
+
+#: templates/unlock.html:2 templates/unlock.txt:1
+msgid ""
+"For security reasons your Firefox Account was put on lockdown. To perform "
+"account-level activities, please click the link to re-verify your account "
+"now."
+msgstr ""
+
+#: templates/unlock.html:3
+msgid "Verify account"
+msgstr ""
+
+#: templates/unlock.txt:2
+msgid "Verify account:"
+msgstr ""
+
+#: templates/verify.html:2 templates/verify.txt:1
+msgid "Almost there"
+msgstr ""
+
+#: templates/verify.html:3 templates/verify.txt:2
+msgid "%(email)s, you're one click away from verifying your Firefox Account."
+msgstr ""
+"%(email)s, tra pochi secondi questo account Firefox Account sarà confermato."
+
+#: templates/verify.html:4
+msgid "Verify"
+msgstr "Conferma"
+
+#: templates/verify.txt:3
+msgid "Verify:"
+msgstr "Conferma:"
 
 #~ msgid "Congratulations!"
 #~ msgstr "Complimenti!"
-
-#~ msgid ""
-#~ "%(email)s, you're one click away from verifying your Firefox Account."
-#~ msgstr ""
-#~ "%(email)s, tra pochi secondi questo account Firefox Account sarà "
-#~ "confermato."
-
-#~ msgid "Verify"
-#~ msgstr "Conferma"
-
-#~ msgid "Verify:"
-#~ msgstr "Conferma:"
 
 #~ msgid "Verify your account"
 #~ msgstr "Conferma l’account"

--- a/locale/ja/LC_MESSAGES/server.po
+++ b/locale/ja/LC_MESSAGES/server.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-02-20 19:15+0000\n"
+"POT-Creation-Date: 2015-02-25 18:58+0000\n"
 "PO-Revision-Date: 2015-02-05 07:17+0000\n"
 "Last-Translator: kaz <kaz_ic@me.com>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -19,7 +19,8 @@ msgstr ""
 #: server/templates/pages/src/503.html:1
 #: server/templates/pages/src/index.html:1
 #: server/templates/pages/src/privacy.html:1
-#: server/templates/pages/src/terms.html:1
+#: server/templates/pages/src/terms.html:1 templates/reset.html:1
+#: templates/unlock.html:1 templates/verify.html:1
 msgid "Firefox Accounts"
 msgstr "Firefox アカウント"
 
@@ -100,48 +101,76 @@ msgstr "Firefox クラウドサービス"
 msgid "Terms of Service"
 msgstr "利用規約"
 
-#~ msgid "Are you sure?"
-#~ msgstr "リセットしますか？"
+#: templates/reset.html:2 templates/reset.txt:1
+msgid "Are you sure?"
+msgstr "リセットしますか？"
 
-#~ msgid "Please confirm that you'd like to reset the password for %(email)s."
-#~ msgstr ""
-#~ "%(email)s に送信されたメールでパスワードのリセットを確認してください。"
+#: templates/reset.html:3 templates/reset.txt:2
+msgid "Please confirm that you'd like to reset the password for %(email)s."
+msgstr "%(email)s に送信されたメールでパスワードのリセットを確認してください。"
 
-#~ msgid "Reset password"
-#~ msgstr "パスワードをリセットする"
+#: templates/reset.html:4
+msgid "Reset password"
+msgstr "パスワードをリセットする"
 
-#~ msgid ""
-#~ "This is an automated email; if you received it in error, no action is "
-#~ "required."
-#~ msgstr ""
-#~ "これは自動で配信されたメールです。心当たりがない場合は、何も行わないでくだ"
-#~ "さい。"
+#: templates/reset.html:5 templates/reset.txt:4 templates/unlock.html:4
+#: templates/unlock.txt:3 templates/verify.html:5 templates/verify.txt:4
+msgid ""
+"This is an automated email; if you received it in error, no action is "
+"required."
+msgstr ""
+"これは自動で配信されたメールです。心当たりがない場合は、何も行わないでくださ"
+"い。"
 
-#~ msgid ""
-#~ "For more information, please visit <a href='https://support.mozilla."
-#~ "org'>Mozilla Support</a>"
-#~ msgstr ""
-#~ "詳しい情報は、<a href='https://support.mozilla.org'>Mozilla サポート</a> "
-#~ "をご覧ください"
+#: templates/reset.html:6 templates/unlock.html:5 templates/verify.html:6
+msgid ""
+"For more information, please visit <a href='https://support.mozilla."
+"org'>Mozilla Support</a>"
+msgstr ""
+"詳しい情報は、<a href='https://support.mozilla.org'>Mozilla サポート</a> をご"
+"覧ください"
 
-#~ msgid "Reset password:"
-#~ msgstr "パスワードをリセットする:"
+#: templates/reset.txt:3
+msgid "Reset password:"
+msgstr "パスワードをリセットする:"
 
-#~ msgid "For more information, please visit https://support.mozilla.org"
-#~ msgstr "詳しい情報は、 https://support.mozilla.org をご覧ください。"
+#: templates/reset.txt:5 templates/unlock.txt:4 templates/verify.txt:5
+msgid "For more information, please visit https://support.mozilla.org"
+msgstr "詳しい情報は、 https://support.mozilla.org をご覧ください。"
+
+#: templates/unlock.html:2 templates/unlock.txt:1
+msgid ""
+"For security reasons your Firefox Account was put on lockdown. To perform "
+"account-level activities, please click the link to re-verify your account "
+"now."
+msgstr ""
+
+#: templates/unlock.html:3
+msgid "Verify account"
+msgstr ""
+
+#: templates/unlock.txt:2
+msgid "Verify account:"
+msgstr ""
+
+#: templates/verify.html:2 templates/verify.txt:1
+msgid "Almost there"
+msgstr ""
+
+#: templates/verify.html:3 templates/verify.txt:2
+msgid "%(email)s, you're one click away from verifying your Firefox Account."
+msgstr "クリックすると %(email)s を Firefox アカウントとして認証できます。"
+
+#: templates/verify.html:4
+msgid "Verify"
+msgstr "認証"
+
+#: templates/verify.txt:3
+msgid "Verify:"
+msgstr "認証:"
 
 #~ msgid "Congratulations!"
 #~ msgstr "おめでとうございます"
-
-#~ msgid ""
-#~ "%(email)s, you're one click away from verifying your Firefox Account."
-#~ msgstr "クリックすると %(email)s を Firefox アカウントとして認証できます。"
-
-#~ msgid "Verify"
-#~ msgstr "認証"
-
-#~ msgid "Verify:"
-#~ msgstr "認証:"
 
 #~ msgid "Verify your account"
 #~ msgstr "アカウントを認証する"

--- a/locale/ja_JP_mac/LC_MESSAGES/server.po
+++ b/locale/ja_JP_mac/LC_MESSAGES/server.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-02-20 19:15+0000\n"
+"POT-Creation-Date: 2015-02-25 18:58+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "Language: \n"
@@ -15,7 +15,8 @@ msgstr ""
 #: server/templates/pages/src/503.html:1
 #: server/templates/pages/src/index.html:1
 #: server/templates/pages/src/privacy.html:1
-#: server/templates/pages/src/terms.html:1
+#: server/templates/pages/src/terms.html:1 templates/reset.html:1
+#: templates/unlock.html:1 templates/verify.html:1
 msgid "Firefox Accounts"
 msgstr ""
 
@@ -87,4 +88,68 @@ msgstr ""
 #: server/templates/pages/src/terms.html:2
 #: server/templates/pages/src/terms.html:5
 msgid "Terms of Service"
+msgstr ""
+
+#: templates/reset.html:2 templates/reset.txt:1
+msgid "Are you sure?"
+msgstr ""
+
+#: templates/reset.html:3 templates/reset.txt:2
+msgid "Please confirm that you'd like to reset the password for %(email)s."
+msgstr ""
+
+#: templates/reset.html:4
+msgid "Reset password"
+msgstr ""
+
+#: templates/reset.html:5 templates/reset.txt:4 templates/unlock.html:4
+#: templates/unlock.txt:3 templates/verify.html:5 templates/verify.txt:4
+msgid ""
+"This is an automated email; if you received it in error, no action is "
+"required."
+msgstr ""
+
+#: templates/reset.html:6 templates/unlock.html:5 templates/verify.html:6
+msgid ""
+"For more information, please visit <a href='https://support.mozilla."
+"org'>Mozilla Support</a>"
+msgstr ""
+
+#: templates/reset.txt:3
+msgid "Reset password:"
+msgstr ""
+
+#: templates/reset.txt:5 templates/unlock.txt:4 templates/verify.txt:5
+msgid "For more information, please visit https://support.mozilla.org"
+msgstr ""
+
+#: templates/unlock.html:2 templates/unlock.txt:1
+msgid ""
+"For security reasons your Firefox Account was put on lockdown. To perform "
+"account-level activities, please click the link to re-verify your account "
+"now."
+msgstr ""
+
+#: templates/unlock.html:3
+msgid "Verify account"
+msgstr ""
+
+#: templates/unlock.txt:2
+msgid "Verify account:"
+msgstr ""
+
+#: templates/verify.html:2 templates/verify.txt:1
+msgid "Almost there"
+msgstr ""
+
+#: templates/verify.html:3 templates/verify.txt:2
+msgid "%(email)s, you're one click away from verifying your Firefox Account."
+msgstr ""
+
+#: templates/verify.html:4
+msgid "Verify"
+msgstr ""
+
+#: templates/verify.txt:3
+msgid "Verify:"
 msgstr ""

--- a/locale/kk/LC_MESSAGES/server.po
+++ b/locale/kk/LC_MESSAGES/server.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-02-20 19:15+0000\n"
+"POT-Creation-Date: 2015-02-25 18:58+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "Language: \n"
@@ -15,7 +15,8 @@ msgstr ""
 #: server/templates/pages/src/503.html:1
 #: server/templates/pages/src/index.html:1
 #: server/templates/pages/src/privacy.html:1
-#: server/templates/pages/src/terms.html:1
+#: server/templates/pages/src/terms.html:1 templates/reset.html:1
+#: templates/unlock.html:1 templates/verify.html:1
 msgid "Firefox Accounts"
 msgstr ""
 
@@ -87,4 +88,68 @@ msgstr ""
 #: server/templates/pages/src/terms.html:2
 #: server/templates/pages/src/terms.html:5
 msgid "Terms of Service"
+msgstr ""
+
+#: templates/reset.html:2 templates/reset.txt:1
+msgid "Are you sure?"
+msgstr ""
+
+#: templates/reset.html:3 templates/reset.txt:2
+msgid "Please confirm that you'd like to reset the password for %(email)s."
+msgstr ""
+
+#: templates/reset.html:4
+msgid "Reset password"
+msgstr ""
+
+#: templates/reset.html:5 templates/reset.txt:4 templates/unlock.html:4
+#: templates/unlock.txt:3 templates/verify.html:5 templates/verify.txt:4
+msgid ""
+"This is an automated email; if you received it in error, no action is "
+"required."
+msgstr ""
+
+#: templates/reset.html:6 templates/unlock.html:5 templates/verify.html:6
+msgid ""
+"For more information, please visit <a href='https://support.mozilla."
+"org'>Mozilla Support</a>"
+msgstr ""
+
+#: templates/reset.txt:3
+msgid "Reset password:"
+msgstr ""
+
+#: templates/reset.txt:5 templates/unlock.txt:4 templates/verify.txt:5
+msgid "For more information, please visit https://support.mozilla.org"
+msgstr ""
+
+#: templates/unlock.html:2 templates/unlock.txt:1
+msgid ""
+"For security reasons your Firefox Account was put on lockdown. To perform "
+"account-level activities, please click the link to re-verify your account "
+"now."
+msgstr ""
+
+#: templates/unlock.html:3
+msgid "Verify account"
+msgstr ""
+
+#: templates/unlock.txt:2
+msgid "Verify account:"
+msgstr ""
+
+#: templates/verify.html:2 templates/verify.txt:1
+msgid "Almost there"
+msgstr ""
+
+#: templates/verify.html:3 templates/verify.txt:2
+msgid "%(email)s, you're one click away from verifying your Firefox Account."
+msgstr ""
+
+#: templates/verify.html:4
+msgid "Verify"
+msgstr ""
+
+#: templates/verify.txt:3
+msgid "Verify:"
 msgstr ""

--- a/locale/km/LC_MESSAGES/server.po
+++ b/locale/km/LC_MESSAGES/server.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-02-20 19:15+0000\n"
+"POT-Creation-Date: 2015-02-25 18:58+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "Language: \n"
@@ -15,7 +15,8 @@ msgstr ""
 #: server/templates/pages/src/503.html:1
 #: server/templates/pages/src/index.html:1
 #: server/templates/pages/src/privacy.html:1
-#: server/templates/pages/src/terms.html:1
+#: server/templates/pages/src/terms.html:1 templates/reset.html:1
+#: templates/unlock.html:1 templates/verify.html:1
 msgid "Firefox Accounts"
 msgstr ""
 
@@ -87,4 +88,68 @@ msgstr ""
 #: server/templates/pages/src/terms.html:2
 #: server/templates/pages/src/terms.html:5
 msgid "Terms of Service"
+msgstr ""
+
+#: templates/reset.html:2 templates/reset.txt:1
+msgid "Are you sure?"
+msgstr ""
+
+#: templates/reset.html:3 templates/reset.txt:2
+msgid "Please confirm that you'd like to reset the password for %(email)s."
+msgstr ""
+
+#: templates/reset.html:4
+msgid "Reset password"
+msgstr ""
+
+#: templates/reset.html:5 templates/reset.txt:4 templates/unlock.html:4
+#: templates/unlock.txt:3 templates/verify.html:5 templates/verify.txt:4
+msgid ""
+"This is an automated email; if you received it in error, no action is "
+"required."
+msgstr ""
+
+#: templates/reset.html:6 templates/unlock.html:5 templates/verify.html:6
+msgid ""
+"For more information, please visit <a href='https://support.mozilla."
+"org'>Mozilla Support</a>"
+msgstr ""
+
+#: templates/reset.txt:3
+msgid "Reset password:"
+msgstr ""
+
+#: templates/reset.txt:5 templates/unlock.txt:4 templates/verify.txt:5
+msgid "For more information, please visit https://support.mozilla.org"
+msgstr ""
+
+#: templates/unlock.html:2 templates/unlock.txt:1
+msgid ""
+"For security reasons your Firefox Account was put on lockdown. To perform "
+"account-level activities, please click the link to re-verify your account "
+"now."
+msgstr ""
+
+#: templates/unlock.html:3
+msgid "Verify account"
+msgstr ""
+
+#: templates/unlock.txt:2
+msgid "Verify account:"
+msgstr ""
+
+#: templates/verify.html:2 templates/verify.txt:1
+msgid "Almost there"
+msgstr ""
+
+#: templates/verify.html:3 templates/verify.txt:2
+msgid "%(email)s, you're one click away from verifying your Firefox Account."
+msgstr ""
+
+#: templates/verify.html:4
+msgid "Verify"
+msgstr ""
+
+#: templates/verify.txt:3
+msgid "Verify:"
 msgstr ""

--- a/locale/kn/LC_MESSAGES/server.po
+++ b/locale/kn/LC_MESSAGES/server.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-02-20 19:15+0000\n"
+"POT-Creation-Date: 2015-02-25 18:58+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "Language: \n"
@@ -15,7 +15,8 @@ msgstr ""
 #: server/templates/pages/src/503.html:1
 #: server/templates/pages/src/index.html:1
 #: server/templates/pages/src/privacy.html:1
-#: server/templates/pages/src/terms.html:1
+#: server/templates/pages/src/terms.html:1 templates/reset.html:1
+#: templates/unlock.html:1 templates/verify.html:1
 msgid "Firefox Accounts"
 msgstr ""
 
@@ -87,4 +88,68 @@ msgstr ""
 #: server/templates/pages/src/terms.html:2
 #: server/templates/pages/src/terms.html:5
 msgid "Terms of Service"
+msgstr ""
+
+#: templates/reset.html:2 templates/reset.txt:1
+msgid "Are you sure?"
+msgstr ""
+
+#: templates/reset.html:3 templates/reset.txt:2
+msgid "Please confirm that you'd like to reset the password for %(email)s."
+msgstr ""
+
+#: templates/reset.html:4
+msgid "Reset password"
+msgstr ""
+
+#: templates/reset.html:5 templates/reset.txt:4 templates/unlock.html:4
+#: templates/unlock.txt:3 templates/verify.html:5 templates/verify.txt:4
+msgid ""
+"This is an automated email; if you received it in error, no action is "
+"required."
+msgstr ""
+
+#: templates/reset.html:6 templates/unlock.html:5 templates/verify.html:6
+msgid ""
+"For more information, please visit <a href='https://support.mozilla."
+"org'>Mozilla Support</a>"
+msgstr ""
+
+#: templates/reset.txt:3
+msgid "Reset password:"
+msgstr ""
+
+#: templates/reset.txt:5 templates/unlock.txt:4 templates/verify.txt:5
+msgid "For more information, please visit https://support.mozilla.org"
+msgstr ""
+
+#: templates/unlock.html:2 templates/unlock.txt:1
+msgid ""
+"For security reasons your Firefox Account was put on lockdown. To perform "
+"account-level activities, please click the link to re-verify your account "
+"now."
+msgstr ""
+
+#: templates/unlock.html:3
+msgid "Verify account"
+msgstr ""
+
+#: templates/unlock.txt:2
+msgid "Verify account:"
+msgstr ""
+
+#: templates/verify.html:2 templates/verify.txt:1
+msgid "Almost there"
+msgstr ""
+
+#: templates/verify.html:3 templates/verify.txt:2
+msgid "%(email)s, you're one click away from verifying your Firefox Account."
+msgstr ""
+
+#: templates/verify.html:4
+msgid "Verify"
+msgstr ""
+
+#: templates/verify.txt:3
+msgid "Verify:"
 msgstr ""

--- a/locale/ko/LC_MESSAGES/server.po
+++ b/locale/ko/LC_MESSAGES/server.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2014-11-10 18:39+0000\n"
+"POT-Creation-Date: 2015-02-25 18:58+0000\n"
 "PO-Revision-Date: 2015-02-23 02:21+0000\n"
 "Last-Translator: Lawrence <ultimate1352@gmail.com>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -14,14 +14,19 @@ msgstr ""
 "X-Generator: Pootle 2.5.0\n"
 "X-POOTLE-MTIME: 1424658074.0\n"
 
-#: server/templates/pages/src/404.html:1 server/templates/pages/src/500.html:1
+#: server/templates/pages/src/400.html:1 server/templates/pages/src/404.html:1
+#: server/templates/pages/src/500.html:1 server/templates/pages/src/502.html:1
 #: server/templates/pages/src/503.html:1
 #: server/templates/pages/src/index.html:1
 #: server/templates/pages/src/privacy.html:1
-#: server/templates/pages/src/terms.html:1 server/templates/email/reset.html:1
-#: server/templates/email/verify.html:1
+#: server/templates/pages/src/terms.html:1 templates/reset.html:1
+#: templates/unlock.html:1 templates/verify.html:1
 msgid "Firefox Accounts"
 msgstr "Firefox 계정"
+
+#: server/templates/pages/src/400.html:2
+msgid "Bad Request"
+msgstr ""
 
 #: server/templates/pages/src/404.html:2
 msgid "Page not found"
@@ -34,7 +39,7 @@ msgid ""
 msgstr "요청하신 페이지를 찾을 수 없습니다. 잘못된 링크를 고치고 있습니다."
 
 #: server/templates/pages/src/404.html:4 server/templates/pages/src/500.html:4
-#: server/templates/pages/src/503.html:4
+#: server/templates/pages/src/502.html:4 server/templates/pages/src/503.html:4
 msgid "Home"
 msgstr "첫화면"
 
@@ -42,10 +47,14 @@ msgstr "첫화면"
 msgid "500 Error"
 msgstr "500 에러"
 
-#: server/templates/pages/src/500.html:3
+#: server/templates/pages/src/500.html:3 server/templates/pages/src/502.html:3
 msgid ""
 "Oh dear, something went wrong there. We've been notified and will get "
 "working on a fix."
+msgstr ""
+
+#: server/templates/pages/src/502.html:2
+msgid "502 Error"
 msgstr ""
 
 #: server/templates/pages/src/503.html:2
@@ -87,27 +96,27 @@ msgstr "Firefox 클라우드 서비스"
 msgid "Terms of Service"
 msgstr "서비스 약관"
 
-#: server/templates/email/reset.html:2 server/templates/email/reset.txt:1
+#: templates/reset.html:2 templates/reset.txt:1
 msgid "Are you sure?"
 msgstr "확인하셨습니까?"
 
-#: server/templates/email/reset.html:3 server/templates/email/reset.txt:2
+#: templates/reset.html:3 templates/reset.txt:2
 msgid "Please confirm that you'd like to reset the password for %(email)s."
 msgstr "%(email)s 계정 암호 재설정을 확인해 주십시오."
 
-#: server/templates/email/reset.html:4
+#: templates/reset.html:4
 msgid "Reset password"
 msgstr "암호 재설정"
 
-#: server/templates/email/reset.html:5 server/templates/email/reset.txt:4
-#: server/templates/email/verify.html:5 server/templates/email/verify.txt:4
+#: templates/reset.html:5 templates/reset.txt:4 templates/unlock.html:4
+#: templates/unlock.txt:3 templates/verify.html:5 templates/verify.txt:4
 msgid ""
 "This is an automated email; if you received it in error, no action is "
 "required."
 msgstr ""
 "이는 자동 전송 메일입니다. 오류로 온 것이라면 아무 동작을 안해도 됩니다."
 
-#: server/templates/email/reset.html:6 server/templates/email/verify.html:6
+#: templates/reset.html:6 templates/unlock.html:5 templates/verify.html:6
 msgid ""
 "For more information, please visit <a href='https://support.mozilla."
 "org'>Mozilla Support</a>"
@@ -115,37 +124,53 @@ msgstr ""
 "더 자세한 정보는 <a href='https://support.mozilla.org'>Mozilla 도움말</a>을 "
 "참고해 주십시오."
 
-#: server/templates/email/reset.txt:3
+#: templates/reset.txt:3
 msgid "Reset password:"
 msgstr "암호 재설정:"
 
-#: server/templates/email/reset.txt:5 server/templates/email/verify.txt:5
+#: templates/reset.txt:5 templates/unlock.txt:4 templates/verify.txt:5
 msgid "For more information, please visit https://support.mozilla.org"
 msgstr "더 자세한 정보는 https://support.mozilla.org 를 방문해 주십시오."
 
-#: server/templates/email/verify.html:2 server/templates/email/verify.txt:1
-msgid "Congratulations!"
-msgstr "성공하였습니다!"
+#: templates/unlock.html:2 templates/unlock.txt:1
+msgid ""
+"For security reasons your Firefox Account was put on lockdown. To perform "
+"account-level activities, please click the link to re-verify your account "
+"now."
+msgstr ""
 
-#: server/templates/email/verify.html:3 server/templates/email/verify.txt:2
+#: templates/unlock.html:3
+msgid "Verify account"
+msgstr ""
+
+#: templates/unlock.txt:2
+msgid "Verify account:"
+msgstr ""
+
+#: templates/verify.html:2 templates/verify.txt:1
+msgid "Almost there"
+msgstr ""
+
+#: templates/verify.html:3 templates/verify.txt:2
 msgid "%(email)s, you're one click away from verifying your Firefox Account."
 msgstr "%(email)s, 이제 한번만 클릭하시면 Firefox 계정 확인이 가능합니다."
 
-#: server/templates/email/verify.html:4
+#: templates/verify.html:4
 msgid "Verify"
 msgstr "계정 확인"
 
-#: server/templates/email/verify.txt:3
+#: templates/verify.txt:3
 msgid "Verify:"
 msgstr "계정 확인:"
 
-#: server/lib/templates.js:63
-msgid "Verify your account"
-msgstr "계정 확인"
+#~ msgid "Congratulations!"
+#~ msgstr "성공하였습니다!"
 
-#: server/lib/templates.js:68
-msgid "Reset your password"
-msgstr "암호 재설정"
+#~ msgid "Verify your account"
+#~ msgstr "계정 확인"
+
+#~ msgid "Reset your password"
+#~ msgstr "암호 재설정"
 
 #~ msgid "System unavailable, try again soon"
 #~ msgstr "시스템 오류입니다, 잠시 후에 다시 시도해 주세요."

--- a/locale/ku/LC_MESSAGES/server.po
+++ b/locale/ku/LC_MESSAGES/server.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-02-20 19:15+0000\n"
+"POT-Creation-Date: 2015-02-25 18:58+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "Language: \n"
@@ -15,7 +15,8 @@ msgstr ""
 #: server/templates/pages/src/503.html:1
 #: server/templates/pages/src/index.html:1
 #: server/templates/pages/src/privacy.html:1
-#: server/templates/pages/src/terms.html:1
+#: server/templates/pages/src/terms.html:1 templates/reset.html:1
+#: templates/unlock.html:1 templates/verify.html:1
 msgid "Firefox Accounts"
 msgstr ""
 
@@ -87,4 +88,68 @@ msgstr ""
 #: server/templates/pages/src/terms.html:2
 #: server/templates/pages/src/terms.html:5
 msgid "Terms of Service"
+msgstr ""
+
+#: templates/reset.html:2 templates/reset.txt:1
+msgid "Are you sure?"
+msgstr ""
+
+#: templates/reset.html:3 templates/reset.txt:2
+msgid "Please confirm that you'd like to reset the password for %(email)s."
+msgstr ""
+
+#: templates/reset.html:4
+msgid "Reset password"
+msgstr ""
+
+#: templates/reset.html:5 templates/reset.txt:4 templates/unlock.html:4
+#: templates/unlock.txt:3 templates/verify.html:5 templates/verify.txt:4
+msgid ""
+"This is an automated email; if you received it in error, no action is "
+"required."
+msgstr ""
+
+#: templates/reset.html:6 templates/unlock.html:5 templates/verify.html:6
+msgid ""
+"For more information, please visit <a href='https://support.mozilla."
+"org'>Mozilla Support</a>"
+msgstr ""
+
+#: templates/reset.txt:3
+msgid "Reset password:"
+msgstr ""
+
+#: templates/reset.txt:5 templates/unlock.txt:4 templates/verify.txt:5
+msgid "For more information, please visit https://support.mozilla.org"
+msgstr ""
+
+#: templates/unlock.html:2 templates/unlock.txt:1
+msgid ""
+"For security reasons your Firefox Account was put on lockdown. To perform "
+"account-level activities, please click the link to re-verify your account "
+"now."
+msgstr ""
+
+#: templates/unlock.html:3
+msgid "Verify account"
+msgstr ""
+
+#: templates/unlock.txt:2
+msgid "Verify account:"
+msgstr ""
+
+#: templates/verify.html:2 templates/verify.txt:1
+msgid "Almost there"
+msgstr ""
+
+#: templates/verify.html:3 templates/verify.txt:2
+msgid "%(email)s, you're one click away from verifying your Firefox Account."
+msgstr ""
+
+#: templates/verify.html:4
+msgid "Verify"
+msgstr ""
+
+#: templates/verify.txt:3
+msgid "Verify:"
 msgstr ""

--- a/locale/lij/LC_MESSAGES/server.po
+++ b/locale/lij/LC_MESSAGES/server.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-02-20 19:15+0000\n"
+"POT-Creation-Date: 2015-02-25 18:58+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "Language: \n"
@@ -15,7 +15,8 @@ msgstr ""
 #: server/templates/pages/src/503.html:1
 #: server/templates/pages/src/index.html:1
 #: server/templates/pages/src/privacy.html:1
-#: server/templates/pages/src/terms.html:1
+#: server/templates/pages/src/terms.html:1 templates/reset.html:1
+#: templates/unlock.html:1 templates/verify.html:1
 msgid "Firefox Accounts"
 msgstr ""
 
@@ -87,4 +88,68 @@ msgstr ""
 #: server/templates/pages/src/terms.html:2
 #: server/templates/pages/src/terms.html:5
 msgid "Terms of Service"
+msgstr ""
+
+#: templates/reset.html:2 templates/reset.txt:1
+msgid "Are you sure?"
+msgstr ""
+
+#: templates/reset.html:3 templates/reset.txt:2
+msgid "Please confirm that you'd like to reset the password for %(email)s."
+msgstr ""
+
+#: templates/reset.html:4
+msgid "Reset password"
+msgstr ""
+
+#: templates/reset.html:5 templates/reset.txt:4 templates/unlock.html:4
+#: templates/unlock.txt:3 templates/verify.html:5 templates/verify.txt:4
+msgid ""
+"This is an automated email; if you received it in error, no action is "
+"required."
+msgstr ""
+
+#: templates/reset.html:6 templates/unlock.html:5 templates/verify.html:6
+msgid ""
+"For more information, please visit <a href='https://support.mozilla."
+"org'>Mozilla Support</a>"
+msgstr ""
+
+#: templates/reset.txt:3
+msgid "Reset password:"
+msgstr ""
+
+#: templates/reset.txt:5 templates/unlock.txt:4 templates/verify.txt:5
+msgid "For more information, please visit https://support.mozilla.org"
+msgstr ""
+
+#: templates/unlock.html:2 templates/unlock.txt:1
+msgid ""
+"For security reasons your Firefox Account was put on lockdown. To perform "
+"account-level activities, please click the link to re-verify your account "
+"now."
+msgstr ""
+
+#: templates/unlock.html:3
+msgid "Verify account"
+msgstr ""
+
+#: templates/unlock.txt:2
+msgid "Verify account:"
+msgstr ""
+
+#: templates/verify.html:2 templates/verify.txt:1
+msgid "Almost there"
+msgstr ""
+
+#: templates/verify.html:3 templates/verify.txt:2
+msgid "%(email)s, you're one click away from verifying your Firefox Account."
+msgstr ""
+
+#: templates/verify.html:4
+msgid "Verify"
+msgstr ""
+
+#: templates/verify.txt:3
+msgid "Verify:"
 msgstr ""

--- a/locale/linux/LC_MESSAGES/server.po
+++ b/locale/linux/LC_MESSAGES/server.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-02-20 19:15+0000\n"
+"POT-Creation-Date: 2015-02-25 18:58+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "Language: \n"
@@ -15,7 +15,8 @@ msgstr ""
 #: server/templates/pages/src/503.html:1
 #: server/templates/pages/src/index.html:1
 #: server/templates/pages/src/privacy.html:1
-#: server/templates/pages/src/terms.html:1
+#: server/templates/pages/src/terms.html:1 templates/reset.html:1
+#: templates/unlock.html:1 templates/verify.html:1
 msgid "Firefox Accounts"
 msgstr ""
 
@@ -87,4 +88,68 @@ msgstr ""
 #: server/templates/pages/src/terms.html:2
 #: server/templates/pages/src/terms.html:5
 msgid "Terms of Service"
+msgstr ""
+
+#: templates/reset.html:2 templates/reset.txt:1
+msgid "Are you sure?"
+msgstr ""
+
+#: templates/reset.html:3 templates/reset.txt:2
+msgid "Please confirm that you'd like to reset the password for %(email)s."
+msgstr ""
+
+#: templates/reset.html:4
+msgid "Reset password"
+msgstr ""
+
+#: templates/reset.html:5 templates/reset.txt:4 templates/unlock.html:4
+#: templates/unlock.txt:3 templates/verify.html:5 templates/verify.txt:4
+msgid ""
+"This is an automated email; if you received it in error, no action is "
+"required."
+msgstr ""
+
+#: templates/reset.html:6 templates/unlock.html:5 templates/verify.html:6
+msgid ""
+"For more information, please visit <a href='https://support.mozilla."
+"org'>Mozilla Support</a>"
+msgstr ""
+
+#: templates/reset.txt:3
+msgid "Reset password:"
+msgstr ""
+
+#: templates/reset.txt:5 templates/unlock.txt:4 templates/verify.txt:5
+msgid "For more information, please visit https://support.mozilla.org"
+msgstr ""
+
+#: templates/unlock.html:2 templates/unlock.txt:1
+msgid ""
+"For security reasons your Firefox Account was put on lockdown. To perform "
+"account-level activities, please click the link to re-verify your account "
+"now."
+msgstr ""
+
+#: templates/unlock.html:3
+msgid "Verify account"
+msgstr ""
+
+#: templates/unlock.txt:2
+msgid "Verify account:"
+msgstr ""
+
+#: templates/verify.html:2 templates/verify.txt:1
+msgid "Almost there"
+msgstr ""
+
+#: templates/verify.html:3 templates/verify.txt:2
+msgid "%(email)s, you're one click away from verifying your Firefox Account."
+msgstr ""
+
+#: templates/verify.html:4
+msgid "Verify"
+msgstr ""
+
+#: templates/verify.txt:3
+msgid "Verify:"
 msgstr ""

--- a/locale/lt/LC_MESSAGES/server.po
+++ b/locale/lt/LC_MESSAGES/server.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-02-20 19:15+0000\n"
+"POT-Creation-Date: 2015-02-25 18:58+0000\n"
 "PO-Revision-Date: 2014-11-09 18:57+0000\n"
 "Last-Translator: Marius <marius.gricius@gmail.com>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -20,7 +20,8 @@ msgstr ""
 #: server/templates/pages/src/503.html:1
 #: server/templates/pages/src/index.html:1
 #: server/templates/pages/src/privacy.html:1
-#: server/templates/pages/src/terms.html:1
+#: server/templates/pages/src/terms.html:1 templates/reset.html:1
+#: templates/unlock.html:1 templates/verify.html:1
 msgid "Firefox Accounts"
 msgstr "„Firefox“ paskyros"
 
@@ -103,49 +104,78 @@ msgstr "„Firefox“ debesijos paslaugos"
 msgid "Terms of Service"
 msgstr "Paslaugos teikimo nuostatai"
 
-#~ msgid "Are you sure?"
-#~ msgstr "Ar esate įsitikinę?"
+#: templates/reset.html:2 templates/reset.txt:1
+msgid "Are you sure?"
+msgstr "Ar esate įsitikinę?"
 
-#~ msgid "Please confirm that you'd like to reset the password for %(email)s."
-#~ msgstr "Patvirtinkite, kad tikrai ketinate atkurti %(email)s slaptažodį."
+#: templates/reset.html:3 templates/reset.txt:2
+msgid "Please confirm that you'd like to reset the password for %(email)s."
+msgstr "Patvirtinkite, kad tikrai ketinate atkurti %(email)s slaptažodį."
 
-#~ msgid "Reset password"
-#~ msgstr "Atkurti slaptažodį"
+#: templates/reset.html:4
+msgid "Reset password"
+msgstr "Atkurti slaptažodį"
 
-#~ msgid ""
-#~ "This is an automated email; if you received it in error, no action is "
-#~ "required."
-#~ msgstr ""
-#~ "Tai automatiškai sugeneruotas laiškas, todėl jei gavote šį laišką per "
-#~ "klaidą, nieko daryti nereikia."
+#: templates/reset.html:5 templates/reset.txt:4 templates/unlock.html:4
+#: templates/unlock.txt:3 templates/verify.html:5 templates/verify.txt:4
+msgid ""
+"This is an automated email; if you received it in error, no action is "
+"required."
+msgstr ""
+"Tai automatiškai sugeneruotas laiškas, todėl jei gavote šį laišką per "
+"klaidą, nieko daryti nereikia."
 
-#~ msgid ""
-#~ "For more information, please visit <a href='https://support.mozilla."
-#~ "org'>Mozilla Support</a>"
-#~ msgstr ""
-#~ "Daugiau informacijos rasite <a href='https://support.mozilla.org'>"
-#~ "„Mozilla“ pagalbos puslapyje</a>"
+#: templates/reset.html:6 templates/unlock.html:5 templates/verify.html:6
+msgid ""
+"For more information, please visit <a href='https://support.mozilla."
+"org'>Mozilla Support</a>"
+msgstr ""
+"Daugiau informacijos rasite <a href='https://support.mozilla.org'>„Mozilla“ "
+"pagalbos puslapyje</a>"
 
-#~ msgid "Reset password:"
-#~ msgstr "Atkurti slaptažodį:"
+#: templates/reset.txt:3
+msgid "Reset password:"
+msgstr "Atkurti slaptažodį:"
 
-#~ msgid "For more information, please visit https://support.mozilla.org"
-#~ msgstr "Daugiau informacijos rasite adresu https://support.mozilla.org"
+#: templates/reset.txt:5 templates/unlock.txt:4 templates/verify.txt:5
+msgid "For more information, please visit https://support.mozilla.org"
+msgstr "Daugiau informacijos rasite adresu https://support.mozilla.org"
+
+#: templates/unlock.html:2 templates/unlock.txt:1
+msgid ""
+"For security reasons your Firefox Account was put on lockdown. To perform "
+"account-level activities, please click the link to re-verify your account "
+"now."
+msgstr ""
+
+#: templates/unlock.html:3
+msgid "Verify account"
+msgstr ""
+
+#: templates/unlock.txt:2
+msgid "Verify account:"
+msgstr ""
+
+#: templates/verify.html:2 templates/verify.txt:1
+msgid "Almost there"
+msgstr ""
+
+#: templates/verify.html:3 templates/verify.txt:2
+msgid "%(email)s, you're one click away from verifying your Firefox Account."
+msgstr ""
+"%(email)s, jūs esate tik per žingsnį nuo savo „Firefox“ paskyros "
+"patvirtinimo."
+
+#: templates/verify.html:4
+msgid "Verify"
+msgstr "Patvirtinkite"
+
+#: templates/verify.txt:3
+msgid "Verify:"
+msgstr "Patvirtinkite:"
 
 #~ msgid "Congratulations!"
 #~ msgstr "Sveikiname!"
-
-#~ msgid ""
-#~ "%(email)s, you're one click away from verifying your Firefox Account."
-#~ msgstr ""
-#~ "%(email)s, jūs esate tik per žingsnį nuo savo „Firefox“ paskyros "
-#~ "patvirtinimo."
-
-#~ msgid "Verify"
-#~ msgstr "Patvirtinkite"
-
-#~ msgid "Verify:"
-#~ msgstr "Patvirtinkite:"
 
 #~ msgid "Verify your account"
 #~ msgstr "Patvirtinkite savo paskyrą"

--- a/locale/lv/LC_MESSAGES/server.po
+++ b/locale/lv/LC_MESSAGES/server.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-02-20 19:15+0000\n"
+"POT-Creation-Date: 2015-02-25 18:58+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "Language: \n"
@@ -15,7 +15,8 @@ msgstr ""
 #: server/templates/pages/src/503.html:1
 #: server/templates/pages/src/index.html:1
 #: server/templates/pages/src/privacy.html:1
-#: server/templates/pages/src/terms.html:1
+#: server/templates/pages/src/terms.html:1 templates/reset.html:1
+#: templates/unlock.html:1 templates/verify.html:1
 msgid "Firefox Accounts"
 msgstr ""
 
@@ -87,4 +88,68 @@ msgstr ""
 #: server/templates/pages/src/terms.html:2
 #: server/templates/pages/src/terms.html:5
 msgid "Terms of Service"
+msgstr ""
+
+#: templates/reset.html:2 templates/reset.txt:1
+msgid "Are you sure?"
+msgstr ""
+
+#: templates/reset.html:3 templates/reset.txt:2
+msgid "Please confirm that you'd like to reset the password for %(email)s."
+msgstr ""
+
+#: templates/reset.html:4
+msgid "Reset password"
+msgstr ""
+
+#: templates/reset.html:5 templates/reset.txt:4 templates/unlock.html:4
+#: templates/unlock.txt:3 templates/verify.html:5 templates/verify.txt:4
+msgid ""
+"This is an automated email; if you received it in error, no action is "
+"required."
+msgstr ""
+
+#: templates/reset.html:6 templates/unlock.html:5 templates/verify.html:6
+msgid ""
+"For more information, please visit <a href='https://support.mozilla."
+"org'>Mozilla Support</a>"
+msgstr ""
+
+#: templates/reset.txt:3
+msgid "Reset password:"
+msgstr ""
+
+#: templates/reset.txt:5 templates/unlock.txt:4 templates/verify.txt:5
+msgid "For more information, please visit https://support.mozilla.org"
+msgstr ""
+
+#: templates/unlock.html:2 templates/unlock.txt:1
+msgid ""
+"For security reasons your Firefox Account was put on lockdown. To perform "
+"account-level activities, please click the link to re-verify your account "
+"now."
+msgstr ""
+
+#: templates/unlock.html:3
+msgid "Verify account"
+msgstr ""
+
+#: templates/unlock.txt:2
+msgid "Verify account:"
+msgstr ""
+
+#: templates/verify.html:2 templates/verify.txt:1
+msgid "Almost there"
+msgstr ""
+
+#: templates/verify.html:3 templates/verify.txt:2
+msgid "%(email)s, you're one click away from verifying your Firefox Account."
+msgstr ""
+
+#: templates/verify.html:4
+msgid "Verify"
+msgstr ""
+
+#: templates/verify.txt:3
+msgid "Verify:"
 msgstr ""

--- a/locale/mai/LC_MESSAGES/server.po
+++ b/locale/mai/LC_MESSAGES/server.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-02-20 19:15+0000\n"
+"POT-Creation-Date: 2015-02-25 18:58+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "Language: \n"
@@ -15,7 +15,8 @@ msgstr ""
 #: server/templates/pages/src/503.html:1
 #: server/templates/pages/src/index.html:1
 #: server/templates/pages/src/privacy.html:1
-#: server/templates/pages/src/terms.html:1
+#: server/templates/pages/src/terms.html:1 templates/reset.html:1
+#: templates/unlock.html:1 templates/verify.html:1
 msgid "Firefox Accounts"
 msgstr ""
 
@@ -87,4 +88,68 @@ msgstr ""
 #: server/templates/pages/src/terms.html:2
 #: server/templates/pages/src/terms.html:5
 msgid "Terms of Service"
+msgstr ""
+
+#: templates/reset.html:2 templates/reset.txt:1
+msgid "Are you sure?"
+msgstr ""
+
+#: templates/reset.html:3 templates/reset.txt:2
+msgid "Please confirm that you'd like to reset the password for %(email)s."
+msgstr ""
+
+#: templates/reset.html:4
+msgid "Reset password"
+msgstr ""
+
+#: templates/reset.html:5 templates/reset.txt:4 templates/unlock.html:4
+#: templates/unlock.txt:3 templates/verify.html:5 templates/verify.txt:4
+msgid ""
+"This is an automated email; if you received it in error, no action is "
+"required."
+msgstr ""
+
+#: templates/reset.html:6 templates/unlock.html:5 templates/verify.html:6
+msgid ""
+"For more information, please visit <a href='https://support.mozilla."
+"org'>Mozilla Support</a>"
+msgstr ""
+
+#: templates/reset.txt:3
+msgid "Reset password:"
+msgstr ""
+
+#: templates/reset.txt:5 templates/unlock.txt:4 templates/verify.txt:5
+msgid "For more information, please visit https://support.mozilla.org"
+msgstr ""
+
+#: templates/unlock.html:2 templates/unlock.txt:1
+msgid ""
+"For security reasons your Firefox Account was put on lockdown. To perform "
+"account-level activities, please click the link to re-verify your account "
+"now."
+msgstr ""
+
+#: templates/unlock.html:3
+msgid "Verify account"
+msgstr ""
+
+#: templates/unlock.txt:2
+msgid "Verify account:"
+msgstr ""
+
+#: templates/verify.html:2 templates/verify.txt:1
+msgid "Almost there"
+msgstr ""
+
+#: templates/verify.html:3 templates/verify.txt:2
+msgid "%(email)s, you're one click away from verifying your Firefox Account."
+msgstr ""
+
+#: templates/verify.html:4
+msgid "Verify"
+msgstr ""
+
+#: templates/verify.txt:3
+msgid "Verify:"
 msgstr ""

--- a/locale/mk/LC_MESSAGES/server.po
+++ b/locale/mk/LC_MESSAGES/server.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-02-20 19:15+0000\n"
+"POT-Creation-Date: 2015-02-25 18:58+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "Language: \n"
@@ -15,7 +15,8 @@ msgstr ""
 #: server/templates/pages/src/503.html:1
 #: server/templates/pages/src/index.html:1
 #: server/templates/pages/src/privacy.html:1
-#: server/templates/pages/src/terms.html:1
+#: server/templates/pages/src/terms.html:1 templates/reset.html:1
+#: templates/unlock.html:1 templates/verify.html:1
 msgid "Firefox Accounts"
 msgstr ""
 
@@ -87,4 +88,68 @@ msgstr ""
 #: server/templates/pages/src/terms.html:2
 #: server/templates/pages/src/terms.html:5
 msgid "Terms of Service"
+msgstr ""
+
+#: templates/reset.html:2 templates/reset.txt:1
+msgid "Are you sure?"
+msgstr ""
+
+#: templates/reset.html:3 templates/reset.txt:2
+msgid "Please confirm that you'd like to reset the password for %(email)s."
+msgstr ""
+
+#: templates/reset.html:4
+msgid "Reset password"
+msgstr ""
+
+#: templates/reset.html:5 templates/reset.txt:4 templates/unlock.html:4
+#: templates/unlock.txt:3 templates/verify.html:5 templates/verify.txt:4
+msgid ""
+"This is an automated email; if you received it in error, no action is "
+"required."
+msgstr ""
+
+#: templates/reset.html:6 templates/unlock.html:5 templates/verify.html:6
+msgid ""
+"For more information, please visit <a href='https://support.mozilla."
+"org'>Mozilla Support</a>"
+msgstr ""
+
+#: templates/reset.txt:3
+msgid "Reset password:"
+msgstr ""
+
+#: templates/reset.txt:5 templates/unlock.txt:4 templates/verify.txt:5
+msgid "For more information, please visit https://support.mozilla.org"
+msgstr ""
+
+#: templates/unlock.html:2 templates/unlock.txt:1
+msgid ""
+"For security reasons your Firefox Account was put on lockdown. To perform "
+"account-level activities, please click the link to re-verify your account "
+"now."
+msgstr ""
+
+#: templates/unlock.html:3
+msgid "Verify account"
+msgstr ""
+
+#: templates/unlock.txt:2
+msgid "Verify account:"
+msgstr ""
+
+#: templates/verify.html:2 templates/verify.txt:1
+msgid "Almost there"
+msgstr ""
+
+#: templates/verify.html:3 templates/verify.txt:2
+msgid "%(email)s, you're one click away from verifying your Firefox Account."
+msgstr ""
+
+#: templates/verify.html:4
+msgid "Verify"
+msgstr ""
+
+#: templates/verify.txt:3
+msgid "Verify:"
 msgstr ""

--- a/locale/ml/LC_MESSAGES/server.po
+++ b/locale/ml/LC_MESSAGES/server.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-02-20 19:15+0000\n"
+"POT-Creation-Date: 2015-02-25 18:58+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "Language: \n"
@@ -15,7 +15,8 @@ msgstr ""
 #: server/templates/pages/src/503.html:1
 #: server/templates/pages/src/index.html:1
 #: server/templates/pages/src/privacy.html:1
-#: server/templates/pages/src/terms.html:1
+#: server/templates/pages/src/terms.html:1 templates/reset.html:1
+#: templates/unlock.html:1 templates/verify.html:1
 msgid "Firefox Accounts"
 msgstr ""
 
@@ -87,4 +88,68 @@ msgstr ""
 #: server/templates/pages/src/terms.html:2
 #: server/templates/pages/src/terms.html:5
 msgid "Terms of Service"
+msgstr ""
+
+#: templates/reset.html:2 templates/reset.txt:1
+msgid "Are you sure?"
+msgstr ""
+
+#: templates/reset.html:3 templates/reset.txt:2
+msgid "Please confirm that you'd like to reset the password for %(email)s."
+msgstr ""
+
+#: templates/reset.html:4
+msgid "Reset password"
+msgstr ""
+
+#: templates/reset.html:5 templates/reset.txt:4 templates/unlock.html:4
+#: templates/unlock.txt:3 templates/verify.html:5 templates/verify.txt:4
+msgid ""
+"This is an automated email; if you received it in error, no action is "
+"required."
+msgstr ""
+
+#: templates/reset.html:6 templates/unlock.html:5 templates/verify.html:6
+msgid ""
+"For more information, please visit <a href='https://support.mozilla."
+"org'>Mozilla Support</a>"
+msgstr ""
+
+#: templates/reset.txt:3
+msgid "Reset password:"
+msgstr ""
+
+#: templates/reset.txt:5 templates/unlock.txt:4 templates/verify.txt:5
+msgid "For more information, please visit https://support.mozilla.org"
+msgstr ""
+
+#: templates/unlock.html:2 templates/unlock.txt:1
+msgid ""
+"For security reasons your Firefox Account was put on lockdown. To perform "
+"account-level activities, please click the link to re-verify your account "
+"now."
+msgstr ""
+
+#: templates/unlock.html:3
+msgid "Verify account"
+msgstr ""
+
+#: templates/unlock.txt:2
+msgid "Verify account:"
+msgstr ""
+
+#: templates/verify.html:2 templates/verify.txt:1
+msgid "Almost there"
+msgstr ""
+
+#: templates/verify.html:3 templates/verify.txt:2
+msgid "%(email)s, you're one click away from verifying your Firefox Account."
+msgstr ""
+
+#: templates/verify.html:4
+msgid "Verify"
+msgstr ""
+
+#: templates/verify.txt:3
+msgid "Verify:"
 msgstr ""

--- a/locale/mr/LC_MESSAGES/server.po
+++ b/locale/mr/LC_MESSAGES/server.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-02-20 19:15+0000\n"
+"POT-Creation-Date: 2015-02-25 18:58+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "Language: \n"
@@ -15,7 +15,8 @@ msgstr ""
 #: server/templates/pages/src/503.html:1
 #: server/templates/pages/src/index.html:1
 #: server/templates/pages/src/privacy.html:1
-#: server/templates/pages/src/terms.html:1
+#: server/templates/pages/src/terms.html:1 templates/reset.html:1
+#: templates/unlock.html:1 templates/verify.html:1
 msgid "Firefox Accounts"
 msgstr ""
 
@@ -87,4 +88,68 @@ msgstr ""
 #: server/templates/pages/src/terms.html:2
 #: server/templates/pages/src/terms.html:5
 msgid "Terms of Service"
+msgstr ""
+
+#: templates/reset.html:2 templates/reset.txt:1
+msgid "Are you sure?"
+msgstr ""
+
+#: templates/reset.html:3 templates/reset.txt:2
+msgid "Please confirm that you'd like to reset the password for %(email)s."
+msgstr ""
+
+#: templates/reset.html:4
+msgid "Reset password"
+msgstr ""
+
+#: templates/reset.html:5 templates/reset.txt:4 templates/unlock.html:4
+#: templates/unlock.txt:3 templates/verify.html:5 templates/verify.txt:4
+msgid ""
+"This is an automated email; if you received it in error, no action is "
+"required."
+msgstr ""
+
+#: templates/reset.html:6 templates/unlock.html:5 templates/verify.html:6
+msgid ""
+"For more information, please visit <a href='https://support.mozilla."
+"org'>Mozilla Support</a>"
+msgstr ""
+
+#: templates/reset.txt:3
+msgid "Reset password:"
+msgstr ""
+
+#: templates/reset.txt:5 templates/unlock.txt:4 templates/verify.txt:5
+msgid "For more information, please visit https://support.mozilla.org"
+msgstr ""
+
+#: templates/unlock.html:2 templates/unlock.txt:1
+msgid ""
+"For security reasons your Firefox Account was put on lockdown. To perform "
+"account-level activities, please click the link to re-verify your account "
+"now."
+msgstr ""
+
+#: templates/unlock.html:3
+msgid "Verify account"
+msgstr ""
+
+#: templates/unlock.txt:2
+msgid "Verify account:"
+msgstr ""
+
+#: templates/verify.html:2 templates/verify.txt:1
+msgid "Almost there"
+msgstr ""
+
+#: templates/verify.html:3 templates/verify.txt:2
+msgid "%(email)s, you're one click away from verifying your Firefox Account."
+msgstr ""
+
+#: templates/verify.html:4
+msgid "Verify"
+msgstr ""
+
+#: templates/verify.txt:3
+msgid "Verify:"
 msgstr ""

--- a/locale/ms/LC_MESSAGES/server.po
+++ b/locale/ms/LC_MESSAGES/server.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-02-20 19:15+0000\n"
+"POT-Creation-Date: 2015-02-25 18:58+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "Language: \n"
@@ -15,7 +15,8 @@ msgstr ""
 #: server/templates/pages/src/503.html:1
 #: server/templates/pages/src/index.html:1
 #: server/templates/pages/src/privacy.html:1
-#: server/templates/pages/src/terms.html:1
+#: server/templates/pages/src/terms.html:1 templates/reset.html:1
+#: templates/unlock.html:1 templates/verify.html:1
 msgid "Firefox Accounts"
 msgstr ""
 
@@ -87,4 +88,68 @@ msgstr ""
 #: server/templates/pages/src/terms.html:2
 #: server/templates/pages/src/terms.html:5
 msgid "Terms of Service"
+msgstr ""
+
+#: templates/reset.html:2 templates/reset.txt:1
+msgid "Are you sure?"
+msgstr ""
+
+#: templates/reset.html:3 templates/reset.txt:2
+msgid "Please confirm that you'd like to reset the password for %(email)s."
+msgstr ""
+
+#: templates/reset.html:4
+msgid "Reset password"
+msgstr ""
+
+#: templates/reset.html:5 templates/reset.txt:4 templates/unlock.html:4
+#: templates/unlock.txt:3 templates/verify.html:5 templates/verify.txt:4
+msgid ""
+"This is an automated email; if you received it in error, no action is "
+"required."
+msgstr ""
+
+#: templates/reset.html:6 templates/unlock.html:5 templates/verify.html:6
+msgid ""
+"For more information, please visit <a href='https://support.mozilla."
+"org'>Mozilla Support</a>"
+msgstr ""
+
+#: templates/reset.txt:3
+msgid "Reset password:"
+msgstr ""
+
+#: templates/reset.txt:5 templates/unlock.txt:4 templates/verify.txt:5
+msgid "For more information, please visit https://support.mozilla.org"
+msgstr ""
+
+#: templates/unlock.html:2 templates/unlock.txt:1
+msgid ""
+"For security reasons your Firefox Account was put on lockdown. To perform "
+"account-level activities, please click the link to re-verify your account "
+"now."
+msgstr ""
+
+#: templates/unlock.html:3
+msgid "Verify account"
+msgstr ""
+
+#: templates/unlock.txt:2
+msgid "Verify account:"
+msgstr ""
+
+#: templates/verify.html:2 templates/verify.txt:1
+msgid "Almost there"
+msgstr ""
+
+#: templates/verify.html:3 templates/verify.txt:2
+msgid "%(email)s, you're one click away from verifying your Firefox Account."
+msgstr ""
+
+#: templates/verify.html:4
+msgid "Verify"
+msgstr ""
+
+#: templates/verify.txt:3
+msgid "Verify:"
 msgstr ""

--- a/locale/nb_NO/LC_MESSAGES/server.po
+++ b/locale/nb_NO/LC_MESSAGES/server.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-02-20 19:15+0000\n"
+"POT-Creation-Date: 2015-02-25 18:58+0000\n"
 "PO-Revision-Date: 2015-01-24 23:00+0000\n"
 "Last-Translator: Håvar <havar@firefox.no>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -19,7 +19,8 @@ msgstr ""
 #: server/templates/pages/src/503.html:1
 #: server/templates/pages/src/index.html:1
 #: server/templates/pages/src/privacy.html:1
-#: server/templates/pages/src/terms.html:1
+#: server/templates/pages/src/terms.html:1 templates/reset.html:1
+#: templates/unlock.html:1 templates/verify.html:1
 msgid "Firefox Accounts"
 msgstr "Firefox-konti"
 
@@ -102,47 +103,76 @@ msgstr "Firefox skytjenester"
 msgid "Terms of Service"
 msgstr "Tjenestevilkår"
 
-#~ msgid "Are you sure?"
-#~ msgstr "Er du sikker?"
+#: templates/reset.html:2 templates/reset.txt:1
+msgid "Are you sure?"
+msgstr "Er du sikker?"
 
-#~ msgid "Please confirm that you'd like to reset the password for %(email)s."
-#~ msgstr "Bekreft at du ønsker å tilbakestille passordet for %(email)s."
+#: templates/reset.html:3 templates/reset.txt:2
+msgid "Please confirm that you'd like to reset the password for %(email)s."
+msgstr "Bekreft at du ønsker å tilbakestille passordet for %(email)s."
 
-#~ msgid "Reset password"
-#~ msgstr "Tilbakestill passord"
+#: templates/reset.html:4
+msgid "Reset password"
+msgstr "Tilbakestill passord"
 
-#~ msgid ""
-#~ "This is an automated email; if you received it in error, no action is "
-#~ "required."
-#~ msgstr ""
-#~ "Dette er en automatisert e-postmelding; hvis du har mottatt denne e-"
-#~ "posten ved en feil,  trenger du ikke å gjøre noe."
+#: templates/reset.html:5 templates/reset.txt:4 templates/unlock.html:4
+#: templates/unlock.txt:3 templates/verify.html:5 templates/verify.txt:4
+msgid ""
+"This is an automated email; if you received it in error, no action is "
+"required."
+msgstr ""
+"Dette er en automatisert e-postmelding; hvis du har mottatt denne e-posten "
+"ved en feil,  trenger du ikke å gjøre noe."
 
-#~ msgid ""
-#~ "For more information, please visit <a href='https://support.mozilla."
-#~ "org'>Mozilla Support</a>"
-#~ msgstr ""
-#~ "For mer informasjon, besøk <a href='https://support.mozilla.org'>Mozilla "
-#~ "Support</a>"
+#: templates/reset.html:6 templates/unlock.html:5 templates/verify.html:6
+msgid ""
+"For more information, please visit <a href='https://support.mozilla."
+"org'>Mozilla Support</a>"
+msgstr ""
+"For mer informasjon, besøk <a href='https://support.mozilla.org'>Mozilla "
+"Support</a>"
 
-#~ msgid "Reset password:"
-#~ msgstr "Tilbakestill passord:"
+#: templates/reset.txt:3
+msgid "Reset password:"
+msgstr "Tilbakestill passord:"
 
-#~ msgid "For more information, please visit https://support.mozilla.org"
-#~ msgstr "For mer informasjon, besøk https://support.mozilla.org"
+#: templates/reset.txt:5 templates/unlock.txt:4 templates/verify.txt:5
+msgid "For more information, please visit https://support.mozilla.org"
+msgstr "For mer informasjon, besøk https://support.mozilla.org"
+
+#: templates/unlock.html:2 templates/unlock.txt:1
+msgid ""
+"For security reasons your Firefox Account was put on lockdown. To perform "
+"account-level activities, please click the link to re-verify your account "
+"now."
+msgstr ""
+
+#: templates/unlock.html:3
+msgid "Verify account"
+msgstr ""
+
+#: templates/unlock.txt:2
+msgid "Verify account:"
+msgstr ""
+
+#: templates/verify.html:2 templates/verify.txt:1
+msgid "Almost there"
+msgstr ""
+
+#: templates/verify.html:3 templates/verify.txt:2
+msgid "%(email)s, you're one click away from verifying your Firefox Account."
+msgstr "%(email)s, du er et klikk unna fra å bekrefte din Firefox-konto."
+
+#: templates/verify.html:4
+msgid "Verify"
+msgstr "Bekreft"
+
+#: templates/verify.txt:3
+msgid "Verify:"
+msgstr "Bekreft:"
 
 #~ msgid "Congratulations!"
 #~ msgstr "Gratulerer!"
-
-#~ msgid ""
-#~ "%(email)s, you're one click away from verifying your Firefox Account."
-#~ msgstr "%(email)s, du er et klikk unna fra å bekrefte din Firefox-konto."
-
-#~ msgid "Verify"
-#~ msgstr "Bekreft"
-
-#~ msgid "Verify:"
-#~ msgstr "Bekreft:"
 
 #~ msgid "Verify your account"
 #~ msgstr "Bekreft din konto"

--- a/locale/ne_NP/LC_MESSAGES/server.po
+++ b/locale/ne_NP/LC_MESSAGES/server.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-02-20 19:15+0000\n"
+"POT-Creation-Date: 2015-02-25 18:58+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,7 +17,8 @@ msgstr ""
 #: server/templates/pages/src/503.html:1
 #: server/templates/pages/src/index.html:1
 #: server/templates/pages/src/privacy.html:1
-#: server/templates/pages/src/terms.html:1
+#: server/templates/pages/src/terms.html:1 templates/reset.html:1
+#: templates/unlock.html:1 templates/verify.html:1
 msgid "Firefox Accounts"
 msgstr ""
 
@@ -89,4 +90,68 @@ msgstr ""
 #: server/templates/pages/src/terms.html:2
 #: server/templates/pages/src/terms.html:5
 msgid "Terms of Service"
+msgstr ""
+
+#: templates/reset.html:2 templates/reset.txt:1
+msgid "Are you sure?"
+msgstr ""
+
+#: templates/reset.html:3 templates/reset.txt:2
+msgid "Please confirm that you'd like to reset the password for %(email)s."
+msgstr ""
+
+#: templates/reset.html:4
+msgid "Reset password"
+msgstr ""
+
+#: templates/reset.html:5 templates/reset.txt:4 templates/unlock.html:4
+#: templates/unlock.txt:3 templates/verify.html:5 templates/verify.txt:4
+msgid ""
+"This is an automated email; if you received it in error, no action is "
+"required."
+msgstr ""
+
+#: templates/reset.html:6 templates/unlock.html:5 templates/verify.html:6
+msgid ""
+"For more information, please visit <a href='https://support.mozilla."
+"org'>Mozilla Support</a>"
+msgstr ""
+
+#: templates/reset.txt:3
+msgid "Reset password:"
+msgstr ""
+
+#: templates/reset.txt:5 templates/unlock.txt:4 templates/verify.txt:5
+msgid "For more information, please visit https://support.mozilla.org"
+msgstr ""
+
+#: templates/unlock.html:2 templates/unlock.txt:1
+msgid ""
+"For security reasons your Firefox Account was put on lockdown. To perform "
+"account-level activities, please click the link to re-verify your account "
+"now."
+msgstr ""
+
+#: templates/unlock.html:3
+msgid "Verify account"
+msgstr ""
+
+#: templates/unlock.txt:2
+msgid "Verify account:"
+msgstr ""
+
+#: templates/verify.html:2 templates/verify.txt:1
+msgid "Almost there"
+msgstr ""
+
+#: templates/verify.html:3 templates/verify.txt:2
+msgid "%(email)s, you're one click away from verifying your Firefox Account."
+msgstr ""
+
+#: templates/verify.html:4
+msgid "Verify"
+msgstr ""
+
+#: templates/verify.txt:3
+msgid "Verify:"
 msgstr ""

--- a/locale/nl/LC_MESSAGES/server.po
+++ b/locale/nl/LC_MESSAGES/server.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-02-20 19:15+0000\n"
+"POT-Creation-Date: 2015-02-25 18:58+0000\n"
 "PO-Revision-Date: 2015-02-21 10:09+0000\n"
 "Last-Translator: Ton <tonnes.mb@gmail.com>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -19,7 +19,8 @@ msgstr ""
 #: server/templates/pages/src/503.html:1
 #: server/templates/pages/src/index.html:1
 #: server/templates/pages/src/privacy.html:1
-#: server/templates/pages/src/terms.html:1
+#: server/templates/pages/src/terms.html:1 templates/reset.html:1
+#: templates/unlock.html:1 templates/verify.html:1
 msgid "Firefox Accounts"
 msgstr "Firefox Accounts"
 
@@ -101,50 +102,78 @@ msgstr "Firefox-cloudservices"
 msgid "Terms of Service"
 msgstr "Servicevoorwaarden"
 
-#~ msgid "Are you sure?"
-#~ msgstr "Weet u het zeker?"
+#: templates/reset.html:2 templates/reset.txt:1
+msgid "Are you sure?"
+msgstr "Weet u het zeker?"
 
-#~ msgid "Please confirm that you'd like to reset the password for %(email)s."
-#~ msgstr ""
-#~ "Bevestig dat u het wachtwoord voor %(email)s opnieuw wilt instellen."
+#: templates/reset.html:3 templates/reset.txt:2
+msgid "Please confirm that you'd like to reset the password for %(email)s."
+msgstr "Bevestig dat u het wachtwoord voor %(email)s opnieuw wilt instellen."
 
-#~ msgid "Reset password"
-#~ msgstr "Wachtwoord herinitialiseren"
+#: templates/reset.html:4
+msgid "Reset password"
+msgstr "Wachtwoord herinitialiseren"
 
-#~ msgid ""
-#~ "This is an automated email; if you received it in error, no action is "
-#~ "required."
-#~ msgstr ""
-#~ "Dit is een automatisch e-mailbericht; als u het per abuis hebt ontvangen, "
-#~ "hoeft u niets te doen."
+#: templates/reset.html:5 templates/reset.txt:4 templates/unlock.html:4
+#: templates/unlock.txt:3 templates/verify.html:5 templates/verify.txt:4
+msgid ""
+"This is an automated email; if you received it in error, no action is "
+"required."
+msgstr ""
+"Dit is een automatisch e-mailbericht; als u het per abuis hebt ontvangen, "
+"hoeft u niets te doen."
 
-#~ msgid ""
-#~ "For more information, please visit <a href='https://support.mozilla."
-#~ "org'>Mozilla Support</a>"
-#~ msgstr ""
-#~ "Bezoek voor meer informatie <a href='https://support.mozilla.org'>Mozilla "
-#~ "Support</a>"
+#: templates/reset.html:6 templates/unlock.html:5 templates/verify.html:6
+msgid ""
+"For more information, please visit <a href='https://support.mozilla."
+"org'>Mozilla Support</a>"
+msgstr ""
+"Bezoek voor meer informatie <a href='https://support.mozilla.org'>Mozilla "
+"Support</a>"
 
-#~ msgid "Reset password:"
-#~ msgstr "Wachtwoord herinitialiseren:"
+#: templates/reset.txt:3
+msgid "Reset password:"
+msgstr "Wachtwoord herinitialiseren:"
 
-#~ msgid "For more information, please visit https://support.mozilla.org"
-#~ msgstr "Bezoek voor meer informatie https://support.mozilla.org"
+#: templates/reset.txt:5 templates/unlock.txt:4 templates/verify.txt:5
+msgid "For more information, please visit https://support.mozilla.org"
+msgstr "Bezoek voor meer informatie https://support.mozilla.org"
+
+#: templates/unlock.html:2 templates/unlock.txt:1
+msgid ""
+"For security reasons your Firefox Account was put on lockdown. To perform "
+"account-level activities, please click the link to re-verify your account "
+"now."
+msgstr ""
+
+#: templates/unlock.html:3
+msgid "Verify account"
+msgstr ""
+
+#: templates/unlock.txt:2
+msgid "Verify account:"
+msgstr ""
+
+#: templates/verify.html:2 templates/verify.txt:1
+msgid "Almost there"
+msgstr ""
+
+#: templates/verify.html:3 templates/verify.txt:2
+msgid "%(email)s, you're one click away from verifying your Firefox Account."
+msgstr ""
+"%(email)s, u bent nog één muisklik verwijderd van verificatie van uw Firefox-"
+"account."
+
+#: templates/verify.html:4
+msgid "Verify"
+msgstr "Verifiëren"
+
+#: templates/verify.txt:3
+msgid "Verify:"
+msgstr "Verifiëren:"
 
 #~ msgid "Congratulations!"
 #~ msgstr "Gefeliciteerd!"
-
-#~ msgid ""
-#~ "%(email)s, you're one click away from verifying your Firefox Account."
-#~ msgstr ""
-#~ "%(email)s, u bent nog één muisklik verwijderd van verificatie van uw "
-#~ "Firefox-account."
-
-#~ msgid "Verify"
-#~ msgstr "Verifiëren"
-
-#~ msgid "Verify:"
-#~ msgstr "Verifiëren:"
 
 #~ msgid "Verify your account"
 #~ msgstr "Verifieer uw account"

--- a/locale/nn_NO/LC_MESSAGES/server.po
+++ b/locale/nn_NO/LC_MESSAGES/server.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-02-20 19:15+0000\n"
+"POT-Creation-Date: 2015-02-25 18:58+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,7 +17,8 @@ msgstr ""
 #: server/templates/pages/src/503.html:1
 #: server/templates/pages/src/index.html:1
 #: server/templates/pages/src/privacy.html:1
-#: server/templates/pages/src/terms.html:1
+#: server/templates/pages/src/terms.html:1 templates/reset.html:1
+#: templates/unlock.html:1 templates/verify.html:1
 msgid "Firefox Accounts"
 msgstr ""
 
@@ -89,4 +90,68 @@ msgstr ""
 #: server/templates/pages/src/terms.html:2
 #: server/templates/pages/src/terms.html:5
 msgid "Terms of Service"
+msgstr ""
+
+#: templates/reset.html:2 templates/reset.txt:1
+msgid "Are you sure?"
+msgstr ""
+
+#: templates/reset.html:3 templates/reset.txt:2
+msgid "Please confirm that you'd like to reset the password for %(email)s."
+msgstr ""
+
+#: templates/reset.html:4
+msgid "Reset password"
+msgstr ""
+
+#: templates/reset.html:5 templates/reset.txt:4 templates/unlock.html:4
+#: templates/unlock.txt:3 templates/verify.html:5 templates/verify.txt:4
+msgid ""
+"This is an automated email; if you received it in error, no action is "
+"required."
+msgstr ""
+
+#: templates/reset.html:6 templates/unlock.html:5 templates/verify.html:6
+msgid ""
+"For more information, please visit <a href='https://support.mozilla."
+"org'>Mozilla Support</a>"
+msgstr ""
+
+#: templates/reset.txt:3
+msgid "Reset password:"
+msgstr ""
+
+#: templates/reset.txt:5 templates/unlock.txt:4 templates/verify.txt:5
+msgid "For more information, please visit https://support.mozilla.org"
+msgstr ""
+
+#: templates/unlock.html:2 templates/unlock.txt:1
+msgid ""
+"For security reasons your Firefox Account was put on lockdown. To perform "
+"account-level activities, please click the link to re-verify your account "
+"now."
+msgstr ""
+
+#: templates/unlock.html:3
+msgid "Verify account"
+msgstr ""
+
+#: templates/unlock.txt:2
+msgid "Verify account:"
+msgstr ""
+
+#: templates/verify.html:2 templates/verify.txt:1
+msgid "Almost there"
+msgstr ""
+
+#: templates/verify.html:3 templates/verify.txt:2
+msgid "%(email)s, you're one click away from verifying your Firefox Account."
+msgstr ""
+
+#: templates/verify.html:4
+msgid "Verify"
+msgstr ""
+
+#: templates/verify.txt:3
+msgid "Verify:"
 msgstr ""

--- a/locale/or/LC_MESSAGES/server.po
+++ b/locale/or/LC_MESSAGES/server.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-02-20 19:15+0000\n"
+"POT-Creation-Date: 2015-02-25 18:58+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "Language: \n"
@@ -15,7 +15,8 @@ msgstr ""
 #: server/templates/pages/src/503.html:1
 #: server/templates/pages/src/index.html:1
 #: server/templates/pages/src/privacy.html:1
-#: server/templates/pages/src/terms.html:1
+#: server/templates/pages/src/terms.html:1 templates/reset.html:1
+#: templates/unlock.html:1 templates/verify.html:1
 msgid "Firefox Accounts"
 msgstr ""
 
@@ -87,4 +88,68 @@ msgstr ""
 #: server/templates/pages/src/terms.html:2
 #: server/templates/pages/src/terms.html:5
 msgid "Terms of Service"
+msgstr ""
+
+#: templates/reset.html:2 templates/reset.txt:1
+msgid "Are you sure?"
+msgstr ""
+
+#: templates/reset.html:3 templates/reset.txt:2
+msgid "Please confirm that you'd like to reset the password for %(email)s."
+msgstr ""
+
+#: templates/reset.html:4
+msgid "Reset password"
+msgstr ""
+
+#: templates/reset.html:5 templates/reset.txt:4 templates/unlock.html:4
+#: templates/unlock.txt:3 templates/verify.html:5 templates/verify.txt:4
+msgid ""
+"This is an automated email; if you received it in error, no action is "
+"required."
+msgstr ""
+
+#: templates/reset.html:6 templates/unlock.html:5 templates/verify.html:6
+msgid ""
+"For more information, please visit <a href='https://support.mozilla."
+"org'>Mozilla Support</a>"
+msgstr ""
+
+#: templates/reset.txt:3
+msgid "Reset password:"
+msgstr ""
+
+#: templates/reset.txt:5 templates/unlock.txt:4 templates/verify.txt:5
+msgid "For more information, please visit https://support.mozilla.org"
+msgstr ""
+
+#: templates/unlock.html:2 templates/unlock.txt:1
+msgid ""
+"For security reasons your Firefox Account was put on lockdown. To perform "
+"account-level activities, please click the link to re-verify your account "
+"now."
+msgstr ""
+
+#: templates/unlock.html:3
+msgid "Verify account"
+msgstr ""
+
+#: templates/unlock.txt:2
+msgid "Verify account:"
+msgstr ""
+
+#: templates/verify.html:2 templates/verify.txt:1
+msgid "Almost there"
+msgstr ""
+
+#: templates/verify.html:3 templates/verify.txt:2
+msgid "%(email)s, you're one click away from verifying your Firefox Account."
+msgstr ""
+
+#: templates/verify.html:4
+msgid "Verify"
+msgstr ""
+
+#: templates/verify.txt:3
+msgid "Verify:"
 msgstr ""

--- a/locale/osx/LC_MESSAGES/server.po
+++ b/locale/osx/LC_MESSAGES/server.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-02-20 19:15+0000\n"
+"POT-Creation-Date: 2015-02-25 18:58+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "Language: \n"
@@ -15,7 +15,8 @@ msgstr ""
 #: server/templates/pages/src/503.html:1
 #: server/templates/pages/src/index.html:1
 #: server/templates/pages/src/privacy.html:1
-#: server/templates/pages/src/terms.html:1
+#: server/templates/pages/src/terms.html:1 templates/reset.html:1
+#: templates/unlock.html:1 templates/verify.html:1
 msgid "Firefox Accounts"
 msgstr ""
 
@@ -87,4 +88,68 @@ msgstr ""
 #: server/templates/pages/src/terms.html:2
 #: server/templates/pages/src/terms.html:5
 msgid "Terms of Service"
+msgstr ""
+
+#: templates/reset.html:2 templates/reset.txt:1
+msgid "Are you sure?"
+msgstr ""
+
+#: templates/reset.html:3 templates/reset.txt:2
+msgid "Please confirm that you'd like to reset the password for %(email)s."
+msgstr ""
+
+#: templates/reset.html:4
+msgid "Reset password"
+msgstr ""
+
+#: templates/reset.html:5 templates/reset.txt:4 templates/unlock.html:4
+#: templates/unlock.txt:3 templates/verify.html:5 templates/verify.txt:4
+msgid ""
+"This is an automated email; if you received it in error, no action is "
+"required."
+msgstr ""
+
+#: templates/reset.html:6 templates/unlock.html:5 templates/verify.html:6
+msgid ""
+"For more information, please visit <a href='https://support.mozilla."
+"org'>Mozilla Support</a>"
+msgstr ""
+
+#: templates/reset.txt:3
+msgid "Reset password:"
+msgstr ""
+
+#: templates/reset.txt:5 templates/unlock.txt:4 templates/verify.txt:5
+msgid "For more information, please visit https://support.mozilla.org"
+msgstr ""
+
+#: templates/unlock.html:2 templates/unlock.txt:1
+msgid ""
+"For security reasons your Firefox Account was put on lockdown. To perform "
+"account-level activities, please click the link to re-verify your account "
+"now."
+msgstr ""
+
+#: templates/unlock.html:3
+msgid "Verify account"
+msgstr ""
+
+#: templates/unlock.txt:2
+msgid "Verify account:"
+msgstr ""
+
+#: templates/verify.html:2 templates/verify.txt:1
+msgid "Almost there"
+msgstr ""
+
+#: templates/verify.html:3 templates/verify.txt:2
+msgid "%(email)s, you're one click away from verifying your Firefox Account."
+msgstr ""
+
+#: templates/verify.html:4
+msgid "Verify"
+msgstr ""
+
+#: templates/verify.txt:3
+msgid "Verify:"
 msgstr ""

--- a/locale/pa/LC_MESSAGES/server.po
+++ b/locale/pa/LC_MESSAGES/server.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-02-20 19:15+0000\n"
+"POT-Creation-Date: 2015-02-25 18:58+0000\n"
 "PO-Revision-Date: 2014-10-12 14:37+0000\n"
 "Last-Translator: Aman <amanpreet.alam@gmail.com>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -19,7 +19,8 @@ msgstr ""
 #: server/templates/pages/src/503.html:1
 #: server/templates/pages/src/index.html:1
 #: server/templates/pages/src/privacy.html:1
-#: server/templates/pages/src/terms.html:1
+#: server/templates/pages/src/terms.html:1 templates/reset.html:1
+#: templates/unlock.html:1 templates/verify.html:1
 msgid "Firefox Accounts"
 msgstr "ਫਾਇਰਫਾਕਸ ਖਾਤਾ"
 
@@ -99,47 +100,74 @@ msgstr "ਫਾਇਰਫਾਕਸ ਕਲਾਉਡ ਸੇਵਾਵਾਂ"
 msgid "Terms of Service"
 msgstr "ਸੇਵਾ ਦੀਆਂ ਸ਼ਰਤਾਂ"
 
-#~ msgid "Are you sure?"
-#~ msgstr "ਕੀ ਤੁਸੀਂ ਚਾਹੁੰਦੇ ਹੋ?"
+#: templates/reset.html:2 templates/reset.txt:1
+msgid "Are you sure?"
+msgstr "ਕੀ ਤੁਸੀਂ ਚਾਹੁੰਦੇ ਹੋ?"
 
-#~ msgid "Please confirm that you'd like to reset the password for %(email)s."
-#~ msgstr "ਪੁਸ਼ਟੀ ਕਰੋ ਜੀ ਕਿ ਤੁਸੀਂ %(email)s ਲਈ ਪਾਸਵਰਡ ਮੁੜ-ਸੈੱਟ ਕਰਨਾ ਚਾਹੁੰਦੇ ਹੋ।"
+#: templates/reset.html:3 templates/reset.txt:2
+msgid "Please confirm that you'd like to reset the password for %(email)s."
+msgstr "ਪੁਸ਼ਟੀ ਕਰੋ ਜੀ ਕਿ ਤੁਸੀਂ %(email)s ਲਈ ਪਾਸਵਰਡ ਮੁੜ-ਸੈੱਟ ਕਰਨਾ ਚਾਹੁੰਦੇ ਹੋ।"
 
-#~ msgid "Reset password"
-#~ msgstr "ਪਾਸਵਰਡ ਮੁੜ-ਸੈੱਟ"
+#: templates/reset.html:4
+msgid "Reset password"
+msgstr "ਪਾਸਵਰਡ ਮੁੜ-ਸੈੱਟ"
 
-#~ msgid ""
-#~ "This is an automated email; if you received it in error, no action is "
-#~ "required."
-#~ msgstr ""
-#~ "ਇਹ ਆਟੋਮੈਟਿਕ ਈਮੇਲ ਹੈ, ਜੇ ਤੁਹਾਨੂੰ ਇਹ ਗਲਤੀ ਨਾਲ ਮਿਲੀ ਹੈ ਤਾਂ ਕੋਈ ਵੀ ਕਾਰਵਾਈ ਕਰਨ ਦੀ ਲੋੜ ਨਹੀਂ "
-#~ "ਹੈ।"
+#: templates/reset.html:5 templates/reset.txt:4 templates/unlock.html:4
+#: templates/unlock.txt:3 templates/verify.html:5 templates/verify.txt:4
+msgid ""
+"This is an automated email; if you received it in error, no action is "
+"required."
+msgstr ""
+"ਇਹ ਆਟੋਮੈਟਿਕ ਈਮੇਲ ਹੈ, ਜੇ ਤੁਹਾਨੂੰ ਇਹ ਗਲਤੀ ਨਾਲ ਮਿਲੀ ਹੈ ਤਾਂ ਕੋਈ ਵੀ ਕਾਰਵਾਈ ਕਰਨ ਦੀ ਲੋੜ ਨਹੀਂ ਹੈ।"
 
-#~ msgid ""
-#~ "For more information, please visit <a href='https://support.mozilla."
-#~ "org'>Mozilla Support</a>"
-#~ msgstr ""
-#~ "ਹੋਰ ਜਾਣਕਾਰੀ ਲਈ <a href='https://support.mozilla.org'>Mozilla Support</a> "
-#~ "ਵੇਖੋ ਜੀ"
+#: templates/reset.html:6 templates/unlock.html:5 templates/verify.html:6
+msgid ""
+"For more information, please visit <a href='https://support.mozilla."
+"org'>Mozilla Support</a>"
+msgstr ""
+"ਹੋਰ ਜਾਣਕਾਰੀ ਲਈ <a href='https://support.mozilla.org'>Mozilla Support</a> ਵੇਖੋ ਜੀ"
 
-#~ msgid "Reset password:"
-#~ msgstr "ਪਾਸਵਰਡ ਮੁੜ-ਸੈੱਟ:"
+#: templates/reset.txt:3
+msgid "Reset password:"
+msgstr "ਪਾਸਵਰਡ ਮੁੜ-ਸੈੱਟ:"
 
-#~ msgid "For more information, please visit https://support.mozilla.org"
-#~ msgstr "ਹੋਰ ਜਿਆਦਾ ਜਾਣਕਾਰੀ ਲਈ, ਵੇਖੋ ਜੀ https://support.mozilla.org"
+#: templates/reset.txt:5 templates/unlock.txt:4 templates/verify.txt:5
+msgid "For more information, please visit https://support.mozilla.org"
+msgstr "ਹੋਰ ਜਿਆਦਾ ਜਾਣਕਾਰੀ ਲਈ, ਵੇਖੋ ਜੀ https://support.mozilla.org"
+
+#: templates/unlock.html:2 templates/unlock.txt:1
+msgid ""
+"For security reasons your Firefox Account was put on lockdown. To perform "
+"account-level activities, please click the link to re-verify your account "
+"now."
+msgstr ""
+
+#: templates/unlock.html:3
+msgid "Verify account"
+msgstr ""
+
+#: templates/unlock.txt:2
+msgid "Verify account:"
+msgstr ""
+
+#: templates/verify.html:2 templates/verify.txt:1
+msgid "Almost there"
+msgstr ""
+
+#: templates/verify.html:3 templates/verify.txt:2
+msgid "%(email)s, you're one click away from verifying your Firefox Account."
+msgstr "%(email)s, ਤੁਸੀਂ ਆਪਣੇ ਫਾਇਰਫਾਕਸ ਖਾਤੇ ਦੀ ਜਾਂਚ ਤੋਂ ਇੱਕ ਕਲਿੱਕ ਦੂਰ ਹੋ।"
+
+#: templates/verify.html:4
+msgid "Verify"
+msgstr "ਪੁਸ਼ਟੀ"
+
+#: templates/verify.txt:3
+msgid "Verify:"
+msgstr "ਪੁਸ਼ਟੀ:"
 
 #~ msgid "Congratulations!"
 #~ msgstr "ਵਧਾਈਆਂ ਜੀ!"
-
-#~ msgid ""
-#~ "%(email)s, you're one click away from verifying your Firefox Account."
-#~ msgstr "%(email)s, ਤੁਸੀਂ ਆਪਣੇ ਫਾਇਰਫਾਕਸ ਖਾਤੇ ਦੀ ਜਾਂਚ ਤੋਂ ਇੱਕ ਕਲਿੱਕ ਦੂਰ ਹੋ।"
-
-#~ msgid "Verify"
-#~ msgstr "ਪੁਸ਼ਟੀ"
-
-#~ msgid "Verify:"
-#~ msgstr "ਪੁਸ਼ਟੀ:"
 
 #~ msgid "Verify your account"
 #~ msgstr "ਤੁਹਾਡੇ ਖਾਤੇ ਦੀ ਜਾਂਚ ਕਰੋ"

--- a/locale/pa_IN/LC_MESSAGES/server.po
+++ b/locale/pa_IN/LC_MESSAGES/server.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-02-20 19:15+0000\n"
+"POT-Creation-Date: 2015-02-25 18:58+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "Language: \n"
@@ -15,7 +15,8 @@ msgstr ""
 #: server/templates/pages/src/503.html:1
 #: server/templates/pages/src/index.html:1
 #: server/templates/pages/src/privacy.html:1
-#: server/templates/pages/src/terms.html:1
+#: server/templates/pages/src/terms.html:1 templates/reset.html:1
+#: templates/unlock.html:1 templates/verify.html:1
 msgid "Firefox Accounts"
 msgstr ""
 
@@ -87,4 +88,68 @@ msgstr ""
 #: server/templates/pages/src/terms.html:2
 #: server/templates/pages/src/terms.html:5
 msgid "Terms of Service"
+msgstr ""
+
+#: templates/reset.html:2 templates/reset.txt:1
+msgid "Are you sure?"
+msgstr ""
+
+#: templates/reset.html:3 templates/reset.txt:2
+msgid "Please confirm that you'd like to reset the password for %(email)s."
+msgstr ""
+
+#: templates/reset.html:4
+msgid "Reset password"
+msgstr ""
+
+#: templates/reset.html:5 templates/reset.txt:4 templates/unlock.html:4
+#: templates/unlock.txt:3 templates/verify.html:5 templates/verify.txt:4
+msgid ""
+"This is an automated email; if you received it in error, no action is "
+"required."
+msgstr ""
+
+#: templates/reset.html:6 templates/unlock.html:5 templates/verify.html:6
+msgid ""
+"For more information, please visit <a href='https://support.mozilla."
+"org'>Mozilla Support</a>"
+msgstr ""
+
+#: templates/reset.txt:3
+msgid "Reset password:"
+msgstr ""
+
+#: templates/reset.txt:5 templates/unlock.txt:4 templates/verify.txt:5
+msgid "For more information, please visit https://support.mozilla.org"
+msgstr ""
+
+#: templates/unlock.html:2 templates/unlock.txt:1
+msgid ""
+"For security reasons your Firefox Account was put on lockdown. To perform "
+"account-level activities, please click the link to re-verify your account "
+"now."
+msgstr ""
+
+#: templates/unlock.html:3
+msgid "Verify account"
+msgstr ""
+
+#: templates/unlock.txt:2
+msgid "Verify account:"
+msgstr ""
+
+#: templates/verify.html:2 templates/verify.txt:1
+msgid "Almost there"
+msgstr ""
+
+#: templates/verify.html:3 templates/verify.txt:2
+msgid "%(email)s, you're one click away from verifying your Firefox Account."
+msgstr ""
+
+#: templates/verify.html:4
+msgid "Verify"
+msgstr ""
+
+#: templates/verify.txt:3
+msgid "Verify:"
 msgstr ""

--- a/locale/pl/LC_MESSAGES/server.po
+++ b/locale/pl/LC_MESSAGES/server.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-02-20 19:15+0000\n"
+"POT-Creation-Date: 2015-02-25 18:58+0000\n"
 "PO-Revision-Date: 2014-03-01 19:41+0000\n"
 "Last-Translator: Bartosz <bpiec@aviary.pl>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -20,7 +20,8 @@ msgstr ""
 #: server/templates/pages/src/503.html:1
 #: server/templates/pages/src/index.html:1
 #: server/templates/pages/src/privacy.html:1
-#: server/templates/pages/src/terms.html:1
+#: server/templates/pages/src/terms.html:1 templates/reset.html:1
+#: templates/unlock.html:1 templates/verify.html:1
 msgid "Firefox Accounts"
 msgstr "Konto Firefox"
 
@@ -96,34 +97,74 @@ msgstr "Konto Firefox"
 msgid "Terms of Service"
 msgstr ""
 
+#: templates/reset.html:2 templates/reset.txt:1
+msgid "Are you sure?"
+msgstr ""
+
+#: templates/reset.html:3 templates/reset.txt:2
 #, fuzzy
-#~ msgid "Please confirm that you'd like to reset the password for %(email)s."
-#~ msgstr "Żądanie zmiany hasła zostało wysłane na adres %(email)s."
+msgid "Please confirm that you'd like to reset the password for %(email)s."
+msgstr "Żądanie zmiany hasła zostało wysłane na adres %(email)s."
 
-#~ msgid "Reset password"
-#~ msgstr "Zmiana hasła"
+#: templates/reset.html:4
+msgid "Reset password"
+msgstr "Zmiana hasła"
 
+#: templates/reset.html:5 templates/reset.txt:4 templates/unlock.html:4
+#: templates/unlock.txt:3 templates/verify.html:5 templates/verify.txt:4
 #, fuzzy
-#~ msgid ""
-#~ "This is an automated email; if you received it in error, no action is "
-#~ "required."
-#~ msgstr "Jeżeli otrzymałeś tego e-maila przez pomyłkę, nic nie musisz robić."
+msgid ""
+"This is an automated email; if you received it in error, no action is "
+"required."
+msgstr "Jeżeli otrzymałeś tego e-maila przez pomyłkę, nic nie musisz robić."
 
-#~ msgid "Reset password:"
-#~ msgstr "Zmień hasło:"
+#: templates/reset.html:6 templates/unlock.html:5 templates/verify.html:6
+msgid ""
+"For more information, please visit <a href='https://support.mozilla."
+"org'>Mozilla Support</a>"
+msgstr ""
 
+#: templates/reset.txt:3
+msgid "Reset password:"
+msgstr "Zmień hasło:"
+
+#: templates/reset.txt:5 templates/unlock.txt:4 templates/verify.txt:5
+msgid "For more information, please visit https://support.mozilla.org"
+msgstr ""
+
+#: templates/unlock.html:2 templates/unlock.txt:1
+msgid ""
+"For security reasons your Firefox Account was put on lockdown. To perform "
+"account-level activities, please click the link to re-verify your account "
+"now."
+msgstr ""
+
+#: templates/unlock.html:3
+msgid "Verify account"
+msgstr ""
+
+#: templates/unlock.txt:2
+msgid "Verify account:"
+msgstr ""
+
+#: templates/verify.html:2 templates/verify.txt:1
+msgid "Almost there"
+msgstr ""
+
+#: templates/verify.html:3 templates/verify.txt:2
 #, fuzzy
-#~ msgid ""
-#~ "%(email)s, you're one click away from verifying your Firefox Account."
-#~ msgstr ""
-#~ "Gratulacje! %(email)s, tylko chwila dzieli Cię od zweryfikowania Twojego "
-#~ "Konta Firefox."
+msgid "%(email)s, you're one click away from verifying your Firefox Account."
+msgstr ""
+"Gratulacje! %(email)s, tylko chwila dzieli Cię od zweryfikowania Twojego "
+"Konta Firefox."
 
-#~ msgid "Verify"
-#~ msgstr "Potwierdź"
+#: templates/verify.html:4
+msgid "Verify"
+msgstr "Potwierdź"
 
-#~ msgid "Verify:"
-#~ msgstr "Potwierdź:"
+#: templates/verify.txt:3
+msgid "Verify:"
+msgstr "Potwierdź:"
 
 #, fuzzy
 #~ msgid "Verify your account"

--- a/locale/pt/LC_MESSAGES/server.po
+++ b/locale/pt/LC_MESSAGES/server.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-02-20 19:15+0000\n"
+"POT-Creation-Date: 2015-02-25 18:58+0000\n"
 "PO-Revision-Date: 2014-10-11 02:38+0000\n"
 "Last-Translator: Cláudio <cesperanc@gmail.com>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -19,7 +19,8 @@ msgstr ""
 #: server/templates/pages/src/503.html:1
 #: server/templates/pages/src/index.html:1
 #: server/templates/pages/src/privacy.html:1
-#: server/templates/pages/src/terms.html:1
+#: server/templates/pages/src/terms.html:1 templates/reset.html:1
+#: templates/unlock.html:1 templates/verify.html:1
 msgid "Firefox Accounts"
 msgstr "Contas do Firefox"
 
@@ -102,48 +103,77 @@ msgstr "Política de Privacidade"
 msgid "Terms of Service"
 msgstr "Termos do Serviço"
 
-#~ msgid "Are you sure?"
-#~ msgstr "Tem a certeza?"
+#: templates/reset.html:2 templates/reset.txt:1
+msgid "Are you sure?"
+msgstr "Tem a certeza?"
 
-#~ msgid "Please confirm that you'd like to reset the password for %(email)s."
-#~ msgstr "Por favor confirme que deseja repor a senha para %(email)s."
+#: templates/reset.html:3 templates/reset.txt:2
+msgid "Please confirm that you'd like to reset the password for %(email)s."
+msgstr "Por favor confirme que deseja repor a senha para %(email)s."
 
-#~ msgid "Reset password"
-#~ msgstr "Repor senha"
+#: templates/reset.html:4
+msgid "Reset password"
+msgstr "Repor senha"
 
-#~ msgid ""
-#~ "This is an automated email; if you received it in error, no action is "
-#~ "required."
-#~ msgstr ""
-#~ "Esta é uma mensagem de correio eletrónico automática; se a recebeu devido "
-#~ "a um erro, nenhuma ação é necessária."
+#: templates/reset.html:5 templates/reset.txt:4 templates/unlock.html:4
+#: templates/unlock.txt:3 templates/verify.html:5 templates/verify.txt:4
+msgid ""
+"This is an automated email; if you received it in error, no action is "
+"required."
+msgstr ""
+"Esta é uma mensagem de correio eletrónico automática; se a recebeu devido a "
+"um erro, nenhuma ação é necessária."
 
-#~ msgid ""
-#~ "For more information, please visit <a href='https://support.mozilla."
-#~ "org'>Mozilla Support</a>"
-#~ msgstr ""
-#~ "Para mais informação, visite o <a href='https://support.mozilla."
-#~ "org'>Apoio da Mozilla</a>"
+#: templates/reset.html:6 templates/unlock.html:5 templates/verify.html:6
+msgid ""
+"For more information, please visit <a href='https://support.mozilla."
+"org'>Mozilla Support</a>"
+msgstr ""
+"Para mais informação, visite o <a href='https://support.mozilla.org'>Apoio "
+"da Mozilla</a>"
 
-#~ msgid "Reset password:"
-#~ msgstr "Repor senha:"
+#: templates/reset.txt:3
+msgid "Reset password:"
+msgstr "Repor senha:"
 
-#~ msgid "For more information, please visit https://support.mozilla.org"
-#~ msgstr "Para mais informação, por favor visite https://support.mozilla.org"
+#: templates/reset.txt:5 templates/unlock.txt:4 templates/verify.txt:5
+msgid "For more information, please visit https://support.mozilla.org"
+msgstr "Para mais informação, por favor visite https://support.mozilla.org"
+
+#: templates/unlock.html:2 templates/unlock.txt:1
+msgid ""
+"For security reasons your Firefox Account was put on lockdown. To perform "
+"account-level activities, please click the link to re-verify your account "
+"now."
+msgstr ""
+
+#: templates/unlock.html:3
+msgid "Verify account"
+msgstr ""
+
+#: templates/unlock.txt:2
+msgid "Verify account:"
+msgstr ""
+
+#: templates/verify.html:2 templates/verify.txt:1
+msgid "Almost there"
+msgstr ""
+
+#: templates/verify.html:3 templates/verify.txt:2
+msgid "%(email)s, you're one click away from verifying your Firefox Account."
+msgstr ""
+"%(email)s, está a um clique de distância de verificar a sua Conta Firefox."
+
+#: templates/verify.html:4
+msgid "Verify"
+msgstr "Verificar"
+
+#: templates/verify.txt:3
+msgid "Verify:"
+msgstr "Verificar:"
 
 #~ msgid "Congratulations!"
 #~ msgstr "Parabéns!"
-
-#~ msgid ""
-#~ "%(email)s, you're one click away from verifying your Firefox Account."
-#~ msgstr ""
-#~ "%(email)s, está a um clique de distância de verificar a sua Conta Firefox."
-
-#~ msgid "Verify"
-#~ msgstr "Verificar"
-
-#~ msgid "Verify:"
-#~ msgstr "Verificar:"
 
 #~ msgid "Verify your account"
 #~ msgstr "Verificar a sua conta"

--- a/locale/pt_BR/LC_MESSAGES/server.po
+++ b/locale/pt_BR/LC_MESSAGES/server.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-02-20 19:15+0000\n"
+"POT-Creation-Date: 2015-02-25 18:58+0000\n"
 "PO-Revision-Date: 2015-02-23 16:14+0000\n"
 "Last-Translator: Marco Aurélio <ouesten@me.com>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -19,7 +19,8 @@ msgstr ""
 #: server/templates/pages/src/503.html:1
 #: server/templates/pages/src/index.html:1
 #: server/templates/pages/src/privacy.html:1
-#: server/templates/pages/src/terms.html:1
+#: server/templates/pages/src/terms.html:1 templates/reset.html:1
+#: templates/unlock.html:1 templates/verify.html:1
 msgid "Firefox Accounts"
 msgstr "Contas do Firefox"
 
@@ -102,50 +103,77 @@ msgstr "Serviços na nuvem do Firefox"
 msgid "Terms of Service"
 msgstr "Termos de serviço"
 
-#~ msgid "Are you sure?"
-#~ msgstr "Você tem certeza?"
+#: templates/reset.html:2 templates/reset.txt:1
+msgid "Are you sure?"
+msgstr "Você tem certeza?"
 
-#~ msgid "Please confirm that you'd like to reset the password for %(email)s."
-#~ msgstr ""
-#~ "Por favor, confirme que você deseja redefinir a senha para %(email)s."
+#: templates/reset.html:3 templates/reset.txt:2
+msgid "Please confirm that you'd like to reset the password for %(email)s."
+msgstr "Por favor, confirme que você deseja redefinir a senha para %(email)s."
 
-#~ msgid "Reset password"
-#~ msgstr "Redefinir senha"
+#: templates/reset.html:4
+msgid "Reset password"
+msgstr "Redefinir senha"
 
-#~ msgid ""
-#~ "This is an automated email; if you received it in error, no action is "
-#~ "required."
-#~ msgstr ""
-#~ "Este é um e-mail automático; Se você recebeu por engano, nenhuma ação é "
-#~ "necessária."
+#: templates/reset.html:5 templates/reset.txt:4 templates/unlock.html:4
+#: templates/unlock.txt:3 templates/verify.html:5 templates/verify.txt:4
+msgid ""
+"This is an automated email; if you received it in error, no action is "
+"required."
+msgstr ""
+"Este é um e-mail automático; Se você recebeu por engano, nenhuma ação é "
+"necessária."
 
-#~ msgid ""
-#~ "For more information, please visit <a href='https://support.mozilla."
-#~ "org'>Mozilla Support</a>"
-#~ msgstr ""
-#~ "Para mais informações, visite o <a href='https://support.mozilla."
-#~ "org'>Suporte Mozilla</a>"
+#: templates/reset.html:6 templates/unlock.html:5 templates/verify.html:6
+msgid ""
+"For more information, please visit <a href='https://support.mozilla."
+"org'>Mozilla Support</a>"
+msgstr ""
+"Para mais informações, visite o <a href='https://support.mozilla."
+"org'>Suporte Mozilla</a>"
 
-#~ msgid "Reset password:"
-#~ msgstr "Redefinir de senha:"
+#: templates/reset.txt:3
+msgid "Reset password:"
+msgstr "Redefinir de senha:"
 
-#~ msgid "For more information, please visit https://support.mozilla.org"
-#~ msgstr "Para mais informações, visite https://support.mozilla.org"
+#: templates/reset.txt:5 templates/unlock.txt:4 templates/verify.txt:5
+msgid "For more information, please visit https://support.mozilla.org"
+msgstr "Para mais informações, visite https://support.mozilla.org"
+
+#: templates/unlock.html:2 templates/unlock.txt:1
+msgid ""
+"For security reasons your Firefox Account was put on lockdown. To perform "
+"account-level activities, please click the link to re-verify your account "
+"now."
+msgstr ""
+
+#: templates/unlock.html:3
+msgid "Verify account"
+msgstr ""
+
+#: templates/unlock.txt:2
+msgid "Verify account:"
+msgstr ""
+
+#: templates/verify.html:2 templates/verify.txt:1
+msgid "Almost there"
+msgstr ""
+
+#: templates/verify.html:3 templates/verify.txt:2
+msgid "%(email)s, you're one click away from verifying your Firefox Account."
+msgstr ""
+"%(email)s, você está a um clique de distância de verificar sua conta Firefox."
+
+#: templates/verify.html:4
+msgid "Verify"
+msgstr "Verificar"
+
+#: templates/verify.txt:3
+msgid "Verify:"
+msgstr "Verificar:"
 
 #~ msgid "Congratulations!"
 #~ msgstr "Parabéns!"
-
-#~ msgid ""
-#~ "%(email)s, you're one click away from verifying your Firefox Account."
-#~ msgstr ""
-#~ "%(email)s, você está a um clique de distância de verificar sua conta "
-#~ "Firefox."
-
-#~ msgid "Verify"
-#~ msgstr "Verificar"
-
-#~ msgid "Verify:"
-#~ msgstr "Verificar:"
 
 #~ msgid "Verify your account"
 #~ msgstr "Verifique a sua conta"

--- a/locale/pt_PT/LC_MESSAGES/server.po
+++ b/locale/pt_PT/LC_MESSAGES/server.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-02-20 19:15+0000\n"
+"POT-Creation-Date: 2015-02-25 18:58+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "Language: \n"
@@ -15,7 +15,8 @@ msgstr ""
 #: server/templates/pages/src/503.html:1
 #: server/templates/pages/src/index.html:1
 #: server/templates/pages/src/privacy.html:1
-#: server/templates/pages/src/terms.html:1
+#: server/templates/pages/src/terms.html:1 templates/reset.html:1
+#: templates/unlock.html:1 templates/verify.html:1
 msgid "Firefox Accounts"
 msgstr ""
 
@@ -87,4 +88,68 @@ msgstr ""
 #: server/templates/pages/src/terms.html:2
 #: server/templates/pages/src/terms.html:5
 msgid "Terms of Service"
+msgstr ""
+
+#: templates/reset.html:2 templates/reset.txt:1
+msgid "Are you sure?"
+msgstr ""
+
+#: templates/reset.html:3 templates/reset.txt:2
+msgid "Please confirm that you'd like to reset the password for %(email)s."
+msgstr ""
+
+#: templates/reset.html:4
+msgid "Reset password"
+msgstr ""
+
+#: templates/reset.html:5 templates/reset.txt:4 templates/unlock.html:4
+#: templates/unlock.txt:3 templates/verify.html:5 templates/verify.txt:4
+msgid ""
+"This is an automated email; if you received it in error, no action is "
+"required."
+msgstr ""
+
+#: templates/reset.html:6 templates/unlock.html:5 templates/verify.html:6
+msgid ""
+"For more information, please visit <a href='https://support.mozilla."
+"org'>Mozilla Support</a>"
+msgstr ""
+
+#: templates/reset.txt:3
+msgid "Reset password:"
+msgstr ""
+
+#: templates/reset.txt:5 templates/unlock.txt:4 templates/verify.txt:5
+msgid "For more information, please visit https://support.mozilla.org"
+msgstr ""
+
+#: templates/unlock.html:2 templates/unlock.txt:1
+msgid ""
+"For security reasons your Firefox Account was put on lockdown. To perform "
+"account-level activities, please click the link to re-verify your account "
+"now."
+msgstr ""
+
+#: templates/unlock.html:3
+msgid "Verify account"
+msgstr ""
+
+#: templates/unlock.txt:2
+msgid "Verify account:"
+msgstr ""
+
+#: templates/verify.html:2 templates/verify.txt:1
+msgid "Almost there"
+msgstr ""
+
+#: templates/verify.html:3 templates/verify.txt:2
+msgid "%(email)s, you're one click away from verifying your Firefox Account."
+msgstr ""
+
+#: templates/verify.html:4
+msgid "Verify"
+msgstr ""
+
+#: templates/verify.txt:3
+msgid "Verify:"
 msgstr ""

--- a/locale/rm/LC_MESSAGES/server.po
+++ b/locale/rm/LC_MESSAGES/server.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-02-20 19:15+0000\n"
+"POT-Creation-Date: 2015-02-25 18:58+0000\n"
 "PO-Revision-Date: 2014-10-31 18:42+0000\n"
 "Last-Translator: Gion-Andri <gion-andri@gmx.ch>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -19,7 +19,8 @@ msgstr ""
 #: server/templates/pages/src/503.html:1
 #: server/templates/pages/src/index.html:1
 #: server/templates/pages/src/privacy.html:1
-#: server/templates/pages/src/terms.html:1
+#: server/templates/pages/src/terms.html:1 templates/reset.html:1
+#: templates/unlock.html:1 templates/verify.html:1
 msgid "Firefox Accounts"
 msgstr "Contos da Firefox"
 
@@ -102,49 +103,78 @@ msgstr "Servetschs cloud da Firefox"
 msgid "Terms of Service"
 msgstr "Cundiziuns dal servetsch"
 
-#~ msgid "Are you sure?"
-#~ msgstr "Es ti segir?"
+#: templates/reset.html:2 templates/reset.txt:1
+msgid "Are you sure?"
+msgstr "Es ti segir?"
 
-#~ msgid "Please confirm that you'd like to reset the password for %(email)s."
-#~ msgstr "Conferma p.pl. che ti vuls redefinir il pled-clav per %(email)s."
+#: templates/reset.html:3 templates/reset.txt:2
+msgid "Please confirm that you'd like to reset the password for %(email)s."
+msgstr "Conferma p.pl. che ti vuls redefinir il pled-clav per %(email)s."
 
-#~ msgid "Reset password"
-#~ msgstr "Redefinir il pled-clav"
+#: templates/reset.html:4
+msgid "Reset password"
+msgstr "Redefinir il pled-clav"
 
-#~ msgid ""
-#~ "This is an automated email; if you received it in error, no action is "
-#~ "required."
-#~ msgstr ""
-#~ "Quai è in e-mail automatic. Sche ti has retschavì per sbagl quest e-mail "
-#~ "na stos ti far nagut."
+#: templates/reset.html:5 templates/reset.txt:4 templates/unlock.html:4
+#: templates/unlock.txt:3 templates/verify.html:5 templates/verify.txt:4
+msgid ""
+"This is an automated email; if you received it in error, no action is "
+"required."
+msgstr ""
+"Quai è in e-mail automatic. Sche ti has retschavì per sbagl quest e-mail na "
+"stos ti far nagut."
 
-#~ msgid ""
-#~ "For more information, please visit <a href='https://support.mozilla."
-#~ "org'>Mozilla Support</a>"
-#~ msgstr ""
-#~ "Visita il <a href='https://support.mozilla.org'>Support da Mozilla</a> "
-#~ "per ulteriuras infurmaziuns."
+#: templates/reset.html:6 templates/unlock.html:5 templates/verify.html:6
+msgid ""
+"For more information, please visit <a href='https://support.mozilla."
+"org'>Mozilla Support</a>"
+msgstr ""
+"Visita il <a href='https://support.mozilla.org'>Support da Mozilla</a> per "
+"ulteriuras infurmaziuns."
 
-#~ msgid "Reset password:"
-#~ msgstr "Redefinir il pled-clav:"
+#: templates/reset.txt:3
+msgid "Reset password:"
+msgstr "Redefinir il pled-clav:"
 
-#~ msgid "For more information, please visit https://support.mozilla.org"
-#~ msgstr "Per dapli infurmaziuns: https://support.mozilla.org"
+#: templates/reset.txt:5 templates/unlock.txt:4 templates/verify.txt:5
+msgid "For more information, please visit https://support.mozilla.org"
+msgstr "Per dapli infurmaziuns: https://support.mozilla.org"
+
+#: templates/unlock.html:2 templates/unlock.txt:1
+msgid ""
+"For security reasons your Firefox Account was put on lockdown. To perform "
+"account-level activities, please click the link to re-verify your account "
+"now."
+msgstr ""
+
+#: templates/unlock.html:3
+msgid "Verify account"
+msgstr ""
+
+#: templates/unlock.txt:2
+msgid "Verify account:"
+msgstr ""
+
+#: templates/verify.html:2 templates/verify.txt:1
+msgid "Almost there"
+msgstr ""
+
+#: templates/verify.html:3 templates/verify.txt:2
+msgid "%(email)s, you're one click away from verifying your Firefox Account."
+msgstr ""
+"%(email)s, i cuzza be pli intginas secundas per verifitgar tes conto da "
+"Firefox."
+
+#: templates/verify.html:4
+msgid "Verify"
+msgstr "Verifitgar"
+
+#: templates/verify.txt:3
+msgid "Verify:"
+msgstr "Verifitgar:"
 
 #~ msgid "Congratulations!"
 #~ msgstr "Gratulaziun!"
-
-#~ msgid ""
-#~ "%(email)s, you're one click away from verifying your Firefox Account."
-#~ msgstr ""
-#~ "%(email)s, i cuzza be pli intginas secundas per verifitgar tes conto da "
-#~ "Firefox."
-
-#~ msgid "Verify"
-#~ msgstr "Verifitgar"
-
-#~ msgid "Verify:"
-#~ msgstr "Verifitgar:"
 
 #~ msgid "Verify your account"
 #~ msgstr "Verifitgar tes conto"

--- a/locale/ro/LC_MESSAGES/server.po
+++ b/locale/ro/LC_MESSAGES/server.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-02-20 19:15+0000\n"
+"POT-Creation-Date: 2015-02-25 18:58+0000\n"
 "PO-Revision-Date: 2014-10-17 12:40+0000\n"
 "Last-Translator: Raul <raul.malea@gmail.com>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -20,7 +20,8 @@ msgstr ""
 #: server/templates/pages/src/503.html:1
 #: server/templates/pages/src/index.html:1
 #: server/templates/pages/src/privacy.html:1
-#: server/templates/pages/src/terms.html:1
+#: server/templates/pages/src/terms.html:1 templates/reset.html:1
+#: templates/unlock.html:1 templates/verify.html:1
 msgid "Firefox Accounts"
 msgstr ""
 
@@ -94,8 +95,66 @@ msgstr ""
 msgid "Terms of Service"
 msgstr "Termenii serviciului"
 
-#~ msgid "Are you sure?"
-#~ msgstr "Sunteți sigur?"
+#: templates/reset.html:2 templates/reset.txt:1
+msgid "Are you sure?"
+msgstr "Sunteți sigur?"
 
-#~ msgid "Reset password"
-#~ msgstr "Resetare parolă"
+#: templates/reset.html:3 templates/reset.txt:2
+msgid "Please confirm that you'd like to reset the password for %(email)s."
+msgstr ""
+
+#: templates/reset.html:4
+msgid "Reset password"
+msgstr "Resetare parolă"
+
+#: templates/reset.html:5 templates/reset.txt:4 templates/unlock.html:4
+#: templates/unlock.txt:3 templates/verify.html:5 templates/verify.txt:4
+msgid ""
+"This is an automated email; if you received it in error, no action is "
+"required."
+msgstr ""
+
+#: templates/reset.html:6 templates/unlock.html:5 templates/verify.html:6
+msgid ""
+"For more information, please visit <a href='https://support.mozilla."
+"org'>Mozilla Support</a>"
+msgstr ""
+
+#: templates/reset.txt:3
+msgid "Reset password:"
+msgstr ""
+
+#: templates/reset.txt:5 templates/unlock.txt:4 templates/verify.txt:5
+msgid "For more information, please visit https://support.mozilla.org"
+msgstr ""
+
+#: templates/unlock.html:2 templates/unlock.txt:1
+msgid ""
+"For security reasons your Firefox Account was put on lockdown. To perform "
+"account-level activities, please click the link to re-verify your account "
+"now."
+msgstr ""
+
+#: templates/unlock.html:3
+msgid "Verify account"
+msgstr ""
+
+#: templates/unlock.txt:2
+msgid "Verify account:"
+msgstr ""
+
+#: templates/verify.html:2 templates/verify.txt:1
+msgid "Almost there"
+msgstr ""
+
+#: templates/verify.html:3 templates/verify.txt:2
+msgid "%(email)s, you're one click away from verifying your Firefox Account."
+msgstr ""
+
+#: templates/verify.html:4
+msgid "Verify"
+msgstr ""
+
+#: templates/verify.txt:3
+msgid "Verify:"
+msgstr ""

--- a/locale/ru/LC_MESSAGES/server.po
+++ b/locale/ru/LC_MESSAGES/server.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: server\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-02-20 19:15+0000\n"
+"POT-Creation-Date: 2015-02-25 18:58+0000\n"
 "PO-Revision-Date: 2014-10-16 21:58+0400\n"
 "Last-Translator: Alexander L. Slovesnik <unghost@mozilla-russia.org>\n"
 "Language-Team: Mozilla Russia <LL@li.org>\n"
@@ -20,7 +20,8 @@ msgstr ""
 #: server/templates/pages/src/503.html:1
 #: server/templates/pages/src/index.html:1
 #: server/templates/pages/src/privacy.html:1
-#: server/templates/pages/src/terms.html:1
+#: server/templates/pages/src/terms.html:1 templates/reset.html:1
+#: templates/unlock.html:1 templates/verify.html:1
 msgid "Firefox Accounts"
 msgstr "Firefox Аккаунты"
 
@@ -103,49 +104,76 @@ msgstr "Облачные службы Firefox"
 msgid "Terms of Service"
 msgstr "Условия службы"
 
-#~ msgid "Are you sure?"
-#~ msgstr "Вы уверены?"
+#: templates/reset.html:2 templates/reset.txt:1
+msgid "Are you sure?"
+msgstr "Вы уверены?"
 
-#~ msgid "Please confirm that you'd like to reset the password for %(email)s."
-#~ msgstr "Подтвердите, что вы хотите восстановить пароль для %(email)s."
+#: templates/reset.html:3 templates/reset.txt:2
+msgid "Please confirm that you'd like to reset the password for %(email)s."
+msgstr "Подтвердите, что вы хотите восстановить пароль для %(email)s."
 
-#~ msgid "Reset password"
-#~ msgstr "Восстановить пароль"
+#: templates/reset.html:4
+msgid "Reset password"
+msgstr "Восстановить пароль"
 
-#~ msgid ""
-#~ "This is an automated email; if you received it in error, no action is "
-#~ "required."
-#~ msgstr ""
-#~ "Это автоматическое сообщение; если вы получили его по ошибке, не "
-#~ "требуется никаких действий."
+#: templates/reset.html:5 templates/reset.txt:4 templates/unlock.html:4
+#: templates/unlock.txt:3 templates/verify.html:5 templates/verify.txt:4
+msgid ""
+"This is an automated email; if you received it in error, no action is "
+"required."
+msgstr ""
+"Это автоматическое сообщение; если вы получили его по ошибке, не требуется "
+"никаких действий."
 
-#~ msgid ""
-#~ "For more information, please visit <a href='https://support.mozilla."
-#~ "org'>Mozilla Support</a>"
-#~ msgstr ""
-#~ "Для получения большей информации, посетите <a href='https://support."
-#~ "mozilla.org'>Сайт поддержки Mozilla</a>"
+#: templates/reset.html:6 templates/unlock.html:5 templates/verify.html:6
+msgid ""
+"For more information, please visit <a href='https://support.mozilla."
+"org'>Mozilla Support</a>"
+msgstr ""
+"Для получения большей информации, посетите <a href='https://support.mozilla."
+"org'>Сайт поддержки Mozilla</a>"
 
-#~ msgid "Reset password:"
-#~ msgstr "Восстановить пароль:"
+#: templates/reset.txt:3
+msgid "Reset password:"
+msgstr "Восстановить пароль:"
 
-#~ msgid "For more information, please visit https://support.mozilla.org"
-#~ msgstr ""
-#~ "Для получения большей информации, посетите https://support.mozilla.org"
+#: templates/reset.txt:5 templates/unlock.txt:4 templates/verify.txt:5
+msgid "For more information, please visit https://support.mozilla.org"
+msgstr "Для получения большей информации, посетите https://support.mozilla.org"
+
+#: templates/unlock.html:2 templates/unlock.txt:1
+msgid ""
+"For security reasons your Firefox Account was put on lockdown. To perform "
+"account-level activities, please click the link to re-verify your account "
+"now."
+msgstr ""
+
+#: templates/unlock.html:3
+msgid "Verify account"
+msgstr ""
+
+#: templates/unlock.txt:2
+msgid "Verify account:"
+msgstr ""
+
+#: templates/verify.html:2 templates/verify.txt:1
+msgid "Almost there"
+msgstr ""
+
+#: templates/verify.html:3 templates/verify.txt:2
+msgid "%(email)s, you're one click away from verifying your Firefox Account."
+msgstr "%(email)s, вы в одном шаге от подтверждения вашего Firefox Аккаунта."
+
+#: templates/verify.html:4
+msgid "Verify"
+msgstr "Подтвердите"
+
+#: templates/verify.txt:3
+msgid "Verify:"
+msgstr "Подтвердите:"
 
 #~ msgid "Congratulations!"
 #~ msgstr "Поздравляем!"
-
-#~ msgid ""
-#~ "%(email)s, you're one click away from verifying your Firefox Account."
-#~ msgstr ""
-#~ "%(email)s, вы в одном шаге от подтверждения вашего Firefox Аккаунта."
-
-#~ msgid "Verify"
-#~ msgstr "Подтвердите"
-
-#~ msgid "Verify:"
-#~ msgstr "Подтвердите:"
 
 #~ msgid "Verify your account"
 #~ msgstr "Подтвердить ваш аккаунт"

--- a/locale/si/LC_MESSAGES/server.po
+++ b/locale/si/LC_MESSAGES/server.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-02-20 19:15+0000\n"
+"POT-Creation-Date: 2015-02-25 18:58+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "Language: \n"
@@ -15,7 +15,8 @@ msgstr ""
 #: server/templates/pages/src/503.html:1
 #: server/templates/pages/src/index.html:1
 #: server/templates/pages/src/privacy.html:1
-#: server/templates/pages/src/terms.html:1
+#: server/templates/pages/src/terms.html:1 templates/reset.html:1
+#: templates/unlock.html:1 templates/verify.html:1
 msgid "Firefox Accounts"
 msgstr ""
 
@@ -87,4 +88,68 @@ msgstr ""
 #: server/templates/pages/src/terms.html:2
 #: server/templates/pages/src/terms.html:5
 msgid "Terms of Service"
+msgstr ""
+
+#: templates/reset.html:2 templates/reset.txt:1
+msgid "Are you sure?"
+msgstr ""
+
+#: templates/reset.html:3 templates/reset.txt:2
+msgid "Please confirm that you'd like to reset the password for %(email)s."
+msgstr ""
+
+#: templates/reset.html:4
+msgid "Reset password"
+msgstr ""
+
+#: templates/reset.html:5 templates/reset.txt:4 templates/unlock.html:4
+#: templates/unlock.txt:3 templates/verify.html:5 templates/verify.txt:4
+msgid ""
+"This is an automated email; if you received it in error, no action is "
+"required."
+msgstr ""
+
+#: templates/reset.html:6 templates/unlock.html:5 templates/verify.html:6
+msgid ""
+"For more information, please visit <a href='https://support.mozilla."
+"org'>Mozilla Support</a>"
+msgstr ""
+
+#: templates/reset.txt:3
+msgid "Reset password:"
+msgstr ""
+
+#: templates/reset.txt:5 templates/unlock.txt:4 templates/verify.txt:5
+msgid "For more information, please visit https://support.mozilla.org"
+msgstr ""
+
+#: templates/unlock.html:2 templates/unlock.txt:1
+msgid ""
+"For security reasons your Firefox Account was put on lockdown. To perform "
+"account-level activities, please click the link to re-verify your account "
+"now."
+msgstr ""
+
+#: templates/unlock.html:3
+msgid "Verify account"
+msgstr ""
+
+#: templates/unlock.txt:2
+msgid "Verify account:"
+msgstr ""
+
+#: templates/verify.html:2 templates/verify.txt:1
+msgid "Almost there"
+msgstr ""
+
+#: templates/verify.html:3 templates/verify.txt:2
+msgid "%(email)s, you're one click away from verifying your Firefox Account."
+msgstr ""
+
+#: templates/verify.html:4
+msgid "Verify"
+msgstr ""
+
+#: templates/verify.txt:3
+msgid "Verify:"
 msgstr ""

--- a/locale/sk/LC_MESSAGES/server.po
+++ b/locale/sk/LC_MESSAGES/server.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-02-20 19:15+0000\n"
+"POT-Creation-Date: 2015-02-25 18:58+0000\n"
 "PO-Revision-Date: 2014-10-14 18:58+0000\n"
 "Last-Translator: Branislav <rozbora@mozilla.sk>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -19,7 +19,8 @@ msgstr ""
 #: server/templates/pages/src/503.html:1
 #: server/templates/pages/src/index.html:1
 #: server/templates/pages/src/privacy.html:1
-#: server/templates/pages/src/terms.html:1
+#: server/templates/pages/src/terms.html:1 templates/reset.html:1
+#: templates/unlock.html:1 templates/verify.html:1
 msgid "Firefox Accounts"
 msgstr "Účty Firefox Account"
 
@@ -99,49 +100,78 @@ msgstr "Cloudové služby Firefox"
 msgid "Terms of Service"
 msgstr "Podmienky používania služby"
 
-#~ msgid "Are you sure?"
-#~ msgstr "Naozaj?"
+#: templates/reset.html:2 templates/reset.txt:1
+msgid "Are you sure?"
+msgstr "Naozaj?"
 
-#~ msgid "Please confirm that you'd like to reset the password for %(email)s."
-#~ msgstr "Naozaj chcete obnoviť heslo pre %(email)s?"
+#: templates/reset.html:3 templates/reset.txt:2
+msgid "Please confirm that you'd like to reset the password for %(email)s."
+msgstr "Naozaj chcete obnoviť heslo pre %(email)s?"
 
-#~ msgid "Reset password"
-#~ msgstr "Obnoviť heslo"
+#: templates/reset.html:4
+msgid "Reset password"
+msgstr "Obnoviť heslo"
 
-#~ msgid ""
-#~ "This is an automated email; if you received it in error, no action is "
-#~ "required."
-#~ msgstr ""
-#~ "Toto je automaticky generovaná správa. Ak ste si ju nevyžiadali, môžete "
-#~ "ju ignorovať."
+#: templates/reset.html:5 templates/reset.txt:4 templates/unlock.html:4
+#: templates/unlock.txt:3 templates/verify.html:5 templates/verify.txt:4
+msgid ""
+"This is an automated email; if you received it in error, no action is "
+"required."
+msgstr ""
+"Toto je automaticky generovaná správa. Ak ste si ju nevyžiadali, môžete ju "
+"ignorovať."
 
-#~ msgid ""
-#~ "For more information, please visit <a href='https://support.mozilla."
-#~ "org'>Mozilla Support</a>"
-#~ msgstr ""
-#~ "Ďalšie informácie získate na stránkach <a href='https://support.mozilla."
-#~ "org'>Mozilla Support</a>"
+#: templates/reset.html:6 templates/unlock.html:5 templates/verify.html:6
+msgid ""
+"For more information, please visit <a href='https://support.mozilla."
+"org'>Mozilla Support</a>"
+msgstr ""
+"Ďalšie informácie získate na stránkach <a href='https://support.mozilla."
+"org'>Mozilla Support</a>"
 
-#~ msgid "Reset password:"
-#~ msgstr "Obnoviť heslo:"
+#: templates/reset.txt:3
+msgid "Reset password:"
+msgstr "Obnoviť heslo:"
 
-#~ msgid "For more information, please visit https://support.mozilla.org"
-#~ msgstr "Ďalšie informácie získate na stránkach https://support.mozilla.org"
+#: templates/reset.txt:5 templates/unlock.txt:4 templates/verify.txt:5
+msgid "For more information, please visit https://support.mozilla.org"
+msgstr "Ďalšie informácie získate na stránkach https://support.mozilla.org"
+
+#: templates/unlock.html:2 templates/unlock.txt:1
+msgid ""
+"For security reasons your Firefox Account was put on lockdown. To perform "
+"account-level activities, please click the link to re-verify your account "
+"now."
+msgstr ""
+
+#: templates/unlock.html:3
+msgid "Verify account"
+msgstr ""
+
+#: templates/unlock.txt:2
+msgid "Verify account:"
+msgstr ""
+
+#: templates/verify.html:2 templates/verify.txt:1
+msgid "Almost there"
+msgstr ""
+
+#: templates/verify.html:3 templates/verify.txt:2
+msgid "%(email)s, you're one click away from verifying your Firefox Account."
+msgstr ""
+"Od overenia Vášho účtu Firefox Account na adrese %(email)s Vás delia len "
+"sekundy."
+
+#: templates/verify.html:4
+msgid "Verify"
+msgstr "Overiť"
+
+#: templates/verify.txt:3
+msgid "Verify:"
+msgstr "Overenie:"
 
 #~ msgid "Congratulations!"
 #~ msgstr "Gratulujeme!"
-
-#~ msgid ""
-#~ "%(email)s, you're one click away from verifying your Firefox Account."
-#~ msgstr ""
-#~ "Od overenia Vášho účtu Firefox Account na adrese %(email)s Vás delia len "
-#~ "sekundy."
-
-#~ msgid "Verify"
-#~ msgstr "Overiť"
-
-#~ msgid "Verify:"
-#~ msgstr "Overenie:"
 
 #~ msgid "Verify your account"
 #~ msgstr "Overiť váš účet"

--- a/locale/sl/LC_MESSAGES/server.po
+++ b/locale/sl/LC_MESSAGES/server.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-02-20 19:15+0000\n"
+"POT-Creation-Date: 2015-02-25 18:58+0000\n"
 "PO-Revision-Date: 2014-10-11 06:42+0000\n"
 "Last-Translator: Matjaž <m@owca.info>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -20,7 +20,8 @@ msgstr ""
 #: server/templates/pages/src/503.html:1
 #: server/templates/pages/src/index.html:1
 #: server/templates/pages/src/privacy.html:1
-#: server/templates/pages/src/terms.html:1
+#: server/templates/pages/src/terms.html:1 templates/reset.html:1
+#: templates/unlock.html:1 templates/verify.html:1
 msgid "Firefox Accounts"
 msgstr "Firefox Računi"
 
@@ -100,47 +101,76 @@ msgstr "Storitve Firefox v oblaku"
 msgid "Terms of Service"
 msgstr "Pogoji uporabe"
 
-#~ msgid "Are you sure?"
-#~ msgstr "Ste prepričani?"
+#: templates/reset.html:2 templates/reset.txt:1
+msgid "Are you sure?"
+msgstr "Ste prepričani?"
 
-#~ msgid "Please confirm that you'd like to reset the password for %(email)s."
-#~ msgstr "Potrdite, da želite ponastaviti geslo za %(email)s."
+#: templates/reset.html:3 templates/reset.txt:2
+msgid "Please confirm that you'd like to reset the password for %(email)s."
+msgstr "Potrdite, da želite ponastaviti geslo za %(email)s."
 
-#~ msgid "Reset password"
-#~ msgstr "Ponastavi geslo"
+#: templates/reset.html:4
+msgid "Reset password"
+msgstr "Ponastavi geslo"
 
-#~ msgid ""
-#~ "This is an automated email; if you received it in error, no action is "
-#~ "required."
-#~ msgstr ""
-#~ "Sporočilo je bilo poslano samodejno. Če ste ga prejeli po pomoti, vam ni "
-#~ "potrebno storiti ničesar."
+#: templates/reset.html:5 templates/reset.txt:4 templates/unlock.html:4
+#: templates/unlock.txt:3 templates/verify.html:5 templates/verify.txt:4
+msgid ""
+"This is an automated email; if you received it in error, no action is "
+"required."
+msgstr ""
+"Sporočilo je bilo poslano samodejno. Če ste ga prejeli po pomoti, vam ni "
+"potrebno storiti ničesar."
 
-#~ msgid ""
-#~ "For more information, please visit <a href='https://support.mozilla."
-#~ "org'>Mozilla Support</a>"
-#~ msgstr ""
-#~ "Za več informacij obiščite <a href='https://support.mozilla.org'>strani s "
-#~ "podporo</a>"
+#: templates/reset.html:6 templates/unlock.html:5 templates/verify.html:6
+msgid ""
+"For more information, please visit <a href='https://support.mozilla."
+"org'>Mozilla Support</a>"
+msgstr ""
+"Za več informacij obiščite <a href='https://support.mozilla.org'>strani s "
+"podporo</a>"
 
-#~ msgid "Reset password:"
-#~ msgstr "Ponastavi geslo:"
+#: templates/reset.txt:3
+msgid "Reset password:"
+msgstr "Ponastavi geslo:"
 
-#~ msgid "For more information, please visit https://support.mozilla.org"
-#~ msgstr "Za več informacij obiščite https://support.mozilla.org"
+#: templates/reset.txt:5 templates/unlock.txt:4 templates/verify.txt:5
+msgid "For more information, please visit https://support.mozilla.org"
+msgstr "Za več informacij obiščite https://support.mozilla.org"
+
+#: templates/unlock.html:2 templates/unlock.txt:1
+msgid ""
+"For security reasons your Firefox Account was put on lockdown. To perform "
+"account-level activities, please click the link to re-verify your account "
+"now."
+msgstr ""
+
+#: templates/unlock.html:3
+msgid "Verify account"
+msgstr ""
+
+#: templates/unlock.txt:2
+msgid "Verify account:"
+msgstr ""
+
+#: templates/verify.html:2 templates/verify.txt:1
+msgid "Almost there"
+msgstr ""
+
+#: templates/verify.html:3 templates/verify.txt:2
+msgid "%(email)s, you're one click away from verifying your Firefox Account."
+msgstr "%(email)s, samo še klik ste oddaljeni od potrditve Firefox Računa."
+
+#: templates/verify.html:4
+msgid "Verify"
+msgstr "Potrdi"
+
+#: templates/verify.txt:3
+msgid "Verify:"
+msgstr "Potrditev:"
 
 #~ msgid "Congratulations!"
 #~ msgstr "Čestitke!"
-
-#~ msgid ""
-#~ "%(email)s, you're one click away from verifying your Firefox Account."
-#~ msgstr "%(email)s, samo še klik ste oddaljeni od potrditve Firefox Računa."
-
-#~ msgid "Verify"
-#~ msgstr "Potrdi"
-
-#~ msgid "Verify:"
-#~ msgstr "Potrditev:"
 
 #~ msgid "Verify your account"
 #~ msgstr "Potrdite svoj račun"

--- a/locale/son/LC_MESSAGES/server.po
+++ b/locale/son/LC_MESSAGES/server.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-02-20 19:15+0000\n"
+"POT-Creation-Date: 2015-02-25 18:58+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "Language: \n"
@@ -15,7 +15,8 @@ msgstr ""
 #: server/templates/pages/src/503.html:1
 #: server/templates/pages/src/index.html:1
 #: server/templates/pages/src/privacy.html:1
-#: server/templates/pages/src/terms.html:1
+#: server/templates/pages/src/terms.html:1 templates/reset.html:1
+#: templates/unlock.html:1 templates/verify.html:1
 msgid "Firefox Accounts"
 msgstr ""
 
@@ -87,4 +88,68 @@ msgstr ""
 #: server/templates/pages/src/terms.html:2
 #: server/templates/pages/src/terms.html:5
 msgid "Terms of Service"
+msgstr ""
+
+#: templates/reset.html:2 templates/reset.txt:1
+msgid "Are you sure?"
+msgstr ""
+
+#: templates/reset.html:3 templates/reset.txt:2
+msgid "Please confirm that you'd like to reset the password for %(email)s."
+msgstr ""
+
+#: templates/reset.html:4
+msgid "Reset password"
+msgstr ""
+
+#: templates/reset.html:5 templates/reset.txt:4 templates/unlock.html:4
+#: templates/unlock.txt:3 templates/verify.html:5 templates/verify.txt:4
+msgid ""
+"This is an automated email; if you received it in error, no action is "
+"required."
+msgstr ""
+
+#: templates/reset.html:6 templates/unlock.html:5 templates/verify.html:6
+msgid ""
+"For more information, please visit <a href='https://support.mozilla."
+"org'>Mozilla Support</a>"
+msgstr ""
+
+#: templates/reset.txt:3
+msgid "Reset password:"
+msgstr ""
+
+#: templates/reset.txt:5 templates/unlock.txt:4 templates/verify.txt:5
+msgid "For more information, please visit https://support.mozilla.org"
+msgstr ""
+
+#: templates/unlock.html:2 templates/unlock.txt:1
+msgid ""
+"For security reasons your Firefox Account was put on lockdown. To perform "
+"account-level activities, please click the link to re-verify your account "
+"now."
+msgstr ""
+
+#: templates/unlock.html:3
+msgid "Verify account"
+msgstr ""
+
+#: templates/unlock.txt:2
+msgid "Verify account:"
+msgstr ""
+
+#: templates/verify.html:2 templates/verify.txt:1
+msgid "Almost there"
+msgstr ""
+
+#: templates/verify.html:3 templates/verify.txt:2
+msgid "%(email)s, you're one click away from verifying your Firefox Account."
+msgstr ""
+
+#: templates/verify.html:4
+msgid "Verify"
+msgstr ""
+
+#: templates/verify.txt:3
+msgid "Verify:"
 msgstr ""

--- a/locale/sq/LC_MESSAGES/server.po
+++ b/locale/sq/LC_MESSAGES/server.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-02-20 19:15+0000\n"
+"POT-Creation-Date: 2015-02-25 18:58+0000\n"
 "PO-Revision-Date: 2015-01-10 18:54+0000\n"
 "Last-Translator: Besnik <besnik@programeshqip.org>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -19,7 +19,8 @@ msgstr ""
 #: server/templates/pages/src/503.html:1
 #: server/templates/pages/src/index.html:1
 #: server/templates/pages/src/privacy.html:1
-#: server/templates/pages/src/terms.html:1
+#: server/templates/pages/src/terms.html:1 templates/reset.html:1
+#: templates/unlock.html:1 templates/verify.html:1
 msgid "Firefox Accounts"
 msgstr ""
 
@@ -92,6 +93,71 @@ msgstr "Shërbime reje nga Firefox-i"
 #: server/templates/pages/src/terms.html:5
 msgid "Terms of Service"
 msgstr "Kushte Shërbimi"
+
+#: templates/reset.html:2 templates/reset.txt:1
+msgid "Are you sure?"
+msgstr ""
+
+#: templates/reset.html:3 templates/reset.txt:2
+msgid "Please confirm that you'd like to reset the password for %(email)s."
+msgstr ""
+
+# Një kërkim i shpejtë te http://fjalori.shkenca.org/ për termin "rivendos" "rivendosje" do të heqë çdo mëdyshje për propozimin e këtushëm.
+#: templates/reset.html:4
+msgid "Reset password"
+msgstr "Ricaktoni fjalëkalimin"
+
+#: templates/reset.html:5 templates/reset.txt:4 templates/unlock.html:4
+#: templates/unlock.txt:3 templates/verify.html:5 templates/verify.txt:4
+msgid ""
+"This is an automated email; if you received it in error, no action is "
+"required."
+msgstr ""
+
+#: templates/reset.html:6 templates/unlock.html:5 templates/verify.html:6
+msgid ""
+"For more information, please visit <a href='https://support.mozilla."
+"org'>Mozilla Support</a>"
+msgstr ""
+
+#: templates/reset.txt:3
+msgid "Reset password:"
+msgstr ""
+
+#: templates/reset.txt:5 templates/unlock.txt:4 templates/verify.txt:5
+msgid "For more information, please visit https://support.mozilla.org"
+msgstr ""
+
+#: templates/unlock.html:2 templates/unlock.txt:1
+msgid ""
+"For security reasons your Firefox Account was put on lockdown. To perform "
+"account-level activities, please click the link to re-verify your account "
+"now."
+msgstr ""
+
+#: templates/unlock.html:3
+msgid "Verify account"
+msgstr ""
+
+#: templates/unlock.txt:2
+msgid "Verify account:"
+msgstr ""
+
+#: templates/verify.html:2 templates/verify.txt:1
+msgid "Almost there"
+msgstr ""
+
+#: templates/verify.html:3 templates/verify.txt:2
+msgid "%(email)s, you're one click away from verifying your Firefox Account."
+msgstr ""
+
+#: templates/verify.html:4
+msgid "Verify"
+msgstr ""
+
+#: templates/verify.txt:3
+msgid "Verify:"
+msgstr ""
 
 #~ msgid "1991"
 #~ msgstr "1991"
@@ -399,10 +465,6 @@ msgstr "Kushte Shërbimi"
 #~ msgstr ""
 #~ "Lidhjes që klikuat i mungonin shenja, dhe mund të jetë dëmtuar nga "
 #~ "klienti juaj email. Kopjojeni adresën me kujdes, dhe riprovoni."
-
-# Një kërkim i shpejtë te http://fjalori.shkenca.org/ për termin "rivendos" "rivendosje" do të heqë çdo mëdyshje për propozimin e këtushëm.
-#~ msgid "Reset password"
-#~ msgstr "Ricaktoni fjalëkalimin"
 
 #~ msgid "Repeat password"
 #~ msgstr "Rijepeni fjalëkalimin"

--- a/locale/sr/LC_MESSAGES/server.po
+++ b/locale/sr/LC_MESSAGES/server.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-02-20 19:15+0000\n"
+"POT-Creation-Date: 2015-02-25 18:58+0000\n"
 "PO-Revision-Date: 2014-10-10 23:22+0000\n"
 "Last-Translator: Vanja <tumbas93@gmail.com>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -20,7 +20,8 @@ msgstr ""
 #: server/templates/pages/src/503.html:1
 #: server/templates/pages/src/index.html:1
 #: server/templates/pages/src/privacy.html:1
-#: server/templates/pages/src/terms.html:1
+#: server/templates/pages/src/terms.html:1 templates/reset.html:1
+#: templates/unlock.html:1 templates/verify.html:1
 msgid "Firefox Accounts"
 msgstr "Firefox налози"
 
@@ -102,48 +103,76 @@ msgstr "Firefox cloud сервиси"
 msgid "Terms of Service"
 msgstr "Услови коришћења"
 
-#~ msgid "Are you sure?"
-#~ msgstr "Да ли сте сигурни?"
+#: templates/reset.html:2 templates/reset.txt:1
+msgid "Are you sure?"
+msgstr "Да ли сте сигурни?"
 
-#~ msgid "Please confirm that you'd like to reset the password for %(email)s."
-#~ msgstr "Молимо Вас потврдите да желите обновити лозинку за %(email)s."
+#: templates/reset.html:3 templates/reset.txt:2
+msgid "Please confirm that you'd like to reset the password for %(email)s."
+msgstr "Молимо Вас потврдите да желите обновити лозинку за %(email)s."
 
-#~ msgid "Reset password"
-#~ msgstr "Ресетуј лозинку"
+#: templates/reset.html:4
+msgid "Reset password"
+msgstr "Ресетуј лозинку"
 
-#~ msgid ""
-#~ "This is an automated email; if you received it in error, no action is "
-#~ "required."
-#~ msgstr ""
-#~ "Ово је аутоматска порука; ако сте је грешком примили, ни једна радња није "
-#~ "потребна."
+#: templates/reset.html:5 templates/reset.txt:4 templates/unlock.html:4
+#: templates/unlock.txt:3 templates/verify.html:5 templates/verify.txt:4
+msgid ""
+"This is an automated email; if you received it in error, no action is "
+"required."
+msgstr ""
+"Ово је аутоматска порука; ако сте је грешком примили, ни једна радња није "
+"потребна."
 
-#~ msgid ""
-#~ "For more information, please visit <a href='https://support.mozilla."
-#~ "org'>Mozilla Support</a>"
-#~ msgstr ""
-#~ "За више информација, молимо Вас посетите <a href='https://support.mozilla."
-#~ "org'>Mozilla подршку</a>"
+#: templates/reset.html:6 templates/unlock.html:5 templates/verify.html:6
+msgid ""
+"For more information, please visit <a href='https://support.mozilla."
+"org'>Mozilla Support</a>"
+msgstr ""
+"За више информација, молимо Вас посетите <a href='https://support.mozilla."
+"org'>Mozilla подршку</a>"
 
-#~ msgid "Reset password:"
-#~ msgstr "Ресетуј лозинку:"
+#: templates/reset.txt:3
+msgid "Reset password:"
+msgstr "Ресетуј лозинку:"
 
-#~ msgid "For more information, please visit https://support.mozilla.org"
-#~ msgstr ""
-#~ "За више информација, молимо Вас посетите https://support.mozilla.org"
+#: templates/reset.txt:5 templates/unlock.txt:4 templates/verify.txt:5
+msgid "For more information, please visit https://support.mozilla.org"
+msgstr "За више информација, молимо Вас посетите https://support.mozilla.org"
+
+#: templates/unlock.html:2 templates/unlock.txt:1
+msgid ""
+"For security reasons your Firefox Account was put on lockdown. To perform "
+"account-level activities, please click the link to re-verify your account "
+"now."
+msgstr ""
+
+#: templates/unlock.html:3
+msgid "Verify account"
+msgstr ""
+
+#: templates/unlock.txt:2
+msgid "Verify account:"
+msgstr ""
+
+#: templates/verify.html:2 templates/verify.txt:1
+msgid "Almost there"
+msgstr ""
+
+#: templates/verify.html:3 templates/verify.txt:2
+msgid "%(email)s, you're one click away from verifying your Firefox Account."
+msgstr "%(email)s, секунде Вас деле од верификације Вашег Firefox налога."
+
+#: templates/verify.html:4
+msgid "Verify"
+msgstr "Верификуј"
+
+#: templates/verify.txt:3
+msgid "Verify:"
+msgstr "Верификуј:"
 
 #~ msgid "Congratulations!"
 #~ msgstr "Честитамо!"
-
-#~ msgid ""
-#~ "%(email)s, you're one click away from verifying your Firefox Account."
-#~ msgstr "%(email)s, секунде Вас деле од верификације Вашег Firefox налога."
-
-#~ msgid "Verify"
-#~ msgstr "Верификуј"
-
-#~ msgid "Verify:"
-#~ msgstr "Верификуј:"
 
 #~ msgid "Verify your account"
 #~ msgstr "Потврдите Ваш налог"

--- a/locale/sr_Latn/LC_MESSAGES/server.po
+++ b/locale/sr_Latn/LC_MESSAGES/server.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-02-20 19:15+0000\n"
+"POT-Creation-Date: 2015-02-25 18:58+0000\n"
 "PO-Revision-Date: 2014-10-10 23:22+0000\n"
 "Last-Translator: Vanja <tumbas93@gmail.com>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -20,7 +20,8 @@ msgstr ""
 #: server/templates/pages/src/503.html:1
 #: server/templates/pages/src/index.html:1
 #: server/templates/pages/src/privacy.html:1
-#: server/templates/pages/src/terms.html:1
+#: server/templates/pages/src/terms.html:1 templates/reset.html:1
+#: templates/unlock.html:1 templates/verify.html:1
 msgid "Firefox Accounts"
 msgstr "Firefox nalozi"
 
@@ -102,48 +103,76 @@ msgstr "Firefox cloud servisi"
 msgid "Terms of Service"
 msgstr "Uslovi korišćenja"
 
-#~ msgid "Are you sure?"
-#~ msgstr "Da li ste sigurni?"
+#: templates/reset.html:2 templates/reset.txt:1
+msgid "Are you sure?"
+msgstr "Da li ste sigurni?"
 
-#~ msgid "Please confirm that you'd like to reset the password for %(email)s."
-#~ msgstr "Molimo Vas potvrdite da želite obnoviti lozinku za %(email)s."
+#: templates/reset.html:3 templates/reset.txt:2
+msgid "Please confirm that you'd like to reset the password for %(email)s."
+msgstr "Molimo Vas potvrdite da želite obnoviti lozinku za %(email)s."
 
-#~ msgid "Reset password"
-#~ msgstr "Resetuj lozinku"
+#: templates/reset.html:4
+msgid "Reset password"
+msgstr "Resetuj lozinku"
 
-#~ msgid ""
-#~ "This is an automated email; if you received it in error, no action is "
-#~ "required."
-#~ msgstr ""
-#~ "Ovo je automatska poruka; ako ste je greškom primili, ni jedna radnja "
-#~ "nije potrebna."
+#: templates/reset.html:5 templates/reset.txt:4 templates/unlock.html:4
+#: templates/unlock.txt:3 templates/verify.html:5 templates/verify.txt:4
+msgid ""
+"This is an automated email; if you received it in error, no action is "
+"required."
+msgstr ""
+"Ovo je automatska poruka; ako ste je greškom primili, ni jedna radnja nije "
+"potrebna."
 
-#~ msgid ""
-#~ "For more information, please visit <a href='https://support.mozilla."
-#~ "org'>Mozilla Support</a>"
-#~ msgstr ""
-#~ "Za više informacija, molimo Vas posetite <a href='https://support.mozilla."
-#~ "org'>Mozilla podršku</a>"
+#: templates/reset.html:6 templates/unlock.html:5 templates/verify.html:6
+msgid ""
+"For more information, please visit <a href='https://support.mozilla."
+"org'>Mozilla Support</a>"
+msgstr ""
+"Za više informacija, molimo Vas posetite <a href='https://support.mozilla."
+"org'>Mozilla podršku</a>"
 
-#~ msgid "Reset password:"
-#~ msgstr "Resetuj lozinku:"
+#: templates/reset.txt:3
+msgid "Reset password:"
+msgstr "Resetuj lozinku:"
 
-#~ msgid "For more information, please visit https://support.mozilla.org"
-#~ msgstr ""
-#~ "Za više informacija, molimo Vas posetite https://support.mozilla.org"
+#: templates/reset.txt:5 templates/unlock.txt:4 templates/verify.txt:5
+msgid "For more information, please visit https://support.mozilla.org"
+msgstr "Za više informacija, molimo Vas posetite https://support.mozilla.org"
+
+#: templates/unlock.html:2 templates/unlock.txt:1
+msgid ""
+"For security reasons your Firefox Account was put on lockdown. To perform "
+"account-level activities, please click the link to re-verify your account "
+"now."
+msgstr ""
+
+#: templates/unlock.html:3
+msgid "Verify account"
+msgstr ""
+
+#: templates/unlock.txt:2
+msgid "Verify account:"
+msgstr ""
+
+#: templates/verify.html:2 templates/verify.txt:1
+msgid "Almost there"
+msgstr ""
+
+#: templates/verify.html:3 templates/verify.txt:2
+msgid "%(email)s, you're one click away from verifying your Firefox Account."
+msgstr "%(email)s, sekunde Vas dele od verifikacije Vašeg Firefox naloga."
+
+#: templates/verify.html:4
+msgid "Verify"
+msgstr "Verifikuj"
+
+#: templates/verify.txt:3
+msgid "Verify:"
+msgstr "Verifikuj:"
 
 #~ msgid "Congratulations!"
 #~ msgstr "Čestitamo!"
-
-#~ msgid ""
-#~ "%(email)s, you're one click away from verifying your Firefox Account."
-#~ msgstr "%(email)s, sekunde Vas dele od verifikacije Vašeg Firefox naloga."
-
-#~ msgid "Verify"
-#~ msgstr "Verifikuj"
-
-#~ msgid "Verify:"
-#~ msgstr "Verifikuj:"
 
 #~ msgid "Verify your account"
 #~ msgstr "Potvrdite Vaš nalog"

--- a/locale/sv/LC_MESSAGES/server.po
+++ b/locale/sv/LC_MESSAGES/server.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-02-20 19:15+0000\n"
+"POT-Creation-Date: 2015-02-25 18:58+0000\n"
 "PO-Revision-Date: 2014-05-03 14:28+0000\n"
 "Last-Translator: Hasse <hasse@jasajudeju.se>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -19,7 +19,8 @@ msgstr ""
 #: server/templates/pages/src/503.html:1
 #: server/templates/pages/src/index.html:1
 #: server/templates/pages/src/privacy.html:1
-#: server/templates/pages/src/terms.html:1
+#: server/templates/pages/src/terms.html:1 templates/reset.html:1
+#: templates/unlock.html:1 templates/verify.html:1
 msgid "Firefox Accounts"
 msgstr "Firefox-konton"
 
@@ -100,47 +101,76 @@ msgstr "Firefox molntjänster"
 msgid "Terms of Service"
 msgstr "Tjänstevillkor"
 
-#~ msgid "Are you sure?"
-#~ msgstr "Är du säker?"
+#: templates/reset.html:2 templates/reset.txt:1
+msgid "Are you sure?"
+msgstr "Är du säker?"
 
-#~ msgid "Please confirm that you'd like to reset the password for %(email)s."
-#~ msgstr "Bekräfta att du vill återställa lösenordet för %(email)s."
+#: templates/reset.html:3 templates/reset.txt:2
+msgid "Please confirm that you'd like to reset the password for %(email)s."
+msgstr "Bekräfta att du vill återställa lösenordet för %(email)s."
 
-#~ msgid "Reset password"
-#~ msgstr "Återställ lösenordet"
+#: templates/reset.html:4
+msgid "Reset password"
+msgstr "Återställ lösenordet"
 
-#~ msgid ""
-#~ "This is an automated email; if you received it in error, no action is "
-#~ "required."
-#~ msgstr ""
-#~ "Det här är ett automatiskt e-postmeddelande; om du felaktigt har fått det "
-#~ "behöver du inte göra något."
+#: templates/reset.html:5 templates/reset.txt:4 templates/unlock.html:4
+#: templates/unlock.txt:3 templates/verify.html:5 templates/verify.txt:4
+msgid ""
+"This is an automated email; if you received it in error, no action is "
+"required."
+msgstr ""
+"Det här är ett automatiskt e-postmeddelande; om du felaktigt har fått det "
+"behöver du inte göra något."
 
-#~ msgid ""
-#~ "For more information, please visit <a href='https://support.mozilla."
-#~ "org'>Mozilla Support</a>"
-#~ msgstr ""
-#~ "För mer information, besök <a href='https://support.mozilla.org'>Mozilla "
-#~ "Support</a>"
+#: templates/reset.html:6 templates/unlock.html:5 templates/verify.html:6
+msgid ""
+"For more information, please visit <a href='https://support.mozilla."
+"org'>Mozilla Support</a>"
+msgstr ""
+"För mer information, besök <a href='https://support.mozilla.org'>Mozilla "
+"Support</a>"
 
-#~ msgid "Reset password:"
-#~ msgstr "Återställ lösenordet:"
+#: templates/reset.txt:3
+msgid "Reset password:"
+msgstr "Återställ lösenordet:"
 
-#~ msgid "For more information, please visit https://support.mozilla.org"
-#~ msgstr "För mer information, besök https://support.mozilla.org"
+#: templates/reset.txt:5 templates/unlock.txt:4 templates/verify.txt:5
+msgid "For more information, please visit https://support.mozilla.org"
+msgstr "För mer information, besök https://support.mozilla.org"
+
+#: templates/unlock.html:2 templates/unlock.txt:1
+msgid ""
+"For security reasons your Firefox Account was put on lockdown. To perform "
+"account-level activities, please click the link to re-verify your account "
+"now."
+msgstr ""
+
+#: templates/unlock.html:3
+msgid "Verify account"
+msgstr ""
+
+#: templates/unlock.txt:2
+msgid "Verify account:"
+msgstr ""
+
+#: templates/verify.html:2 templates/verify.txt:1
+msgid "Almost there"
+msgstr ""
+
+#: templates/verify.html:3 templates/verify.txt:2
+msgid "%(email)s, you're one click away from verifying your Firefox Account."
+msgstr "%(email)s, du är nu sekunder ifrån att bekräfta ditt Firefox-konto."
+
+#: templates/verify.html:4
+msgid "Verify"
+msgstr "Bekräfta"
+
+#: templates/verify.txt:3
+msgid "Verify:"
+msgstr "Bekräfta:"
 
 #~ msgid "Congratulations!"
 #~ msgstr "Grattis!"
-
-#~ msgid ""
-#~ "%(email)s, you're one click away from verifying your Firefox Account."
-#~ msgstr "%(email)s, du är nu sekunder ifrån att bekräfta ditt Firefox-konto."
-
-#~ msgid "Verify"
-#~ msgstr "Bekräfta"
-
-#~ msgid "Verify:"
-#~ msgstr "Bekräfta:"
 
 #~ msgid "Verify your account"
 #~ msgstr "Bekräfta ditt konto"

--- a/locale/sv_SE/LC_MESSAGES/server.po
+++ b/locale/sv_SE/LC_MESSAGES/server.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-02-20 19:15+0000\n"
+"POT-Creation-Date: 2015-02-25 18:58+0000\n"
 "PO-Revision-Date: 2015-01-29 20:53+0000\n"
 "Last-Translator: Andreas <az@kth.se>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -19,7 +19,8 @@ msgstr ""
 #: server/templates/pages/src/503.html:1
 #: server/templates/pages/src/index.html:1
 #: server/templates/pages/src/privacy.html:1
-#: server/templates/pages/src/terms.html:1
+#: server/templates/pages/src/terms.html:1 templates/reset.html:1
+#: templates/unlock.html:1 templates/verify.html:1
 msgid "Firefox Accounts"
 msgstr "Firefox-konton"
 
@@ -101,47 +102,76 @@ msgstr "Firefox molntjänster"
 msgid "Terms of Service"
 msgstr "Tjänstevillkor"
 
-#~ msgid "Are you sure?"
-#~ msgstr "Är du säker?"
+#: templates/reset.html:2 templates/reset.txt:1
+msgid "Are you sure?"
+msgstr "Är du säker?"
 
-#~ msgid "Please confirm that you'd like to reset the password for %(email)s."
-#~ msgstr "Bekräfta att du vill återställa lösenordet för %(email)s."
+#: templates/reset.html:3 templates/reset.txt:2
+msgid "Please confirm that you'd like to reset the password for %(email)s."
+msgstr "Bekräfta att du vill återställa lösenordet för %(email)s."
 
-#~ msgid "Reset password"
-#~ msgstr "Återställ lösenordet"
+#: templates/reset.html:4
+msgid "Reset password"
+msgstr "Återställ lösenordet"
 
-#~ msgid ""
-#~ "This is an automated email; if you received it in error, no action is "
-#~ "required."
-#~ msgstr ""
-#~ "Det här är ett automatiskt e-postmeddelande; om du felaktigt har fått det "
-#~ "behöver du inte göra något."
+#: templates/reset.html:5 templates/reset.txt:4 templates/unlock.html:4
+#: templates/unlock.txt:3 templates/verify.html:5 templates/verify.txt:4
+msgid ""
+"This is an automated email; if you received it in error, no action is "
+"required."
+msgstr ""
+"Det här är ett automatiskt e-postmeddelande; om du felaktigt har fått det "
+"behöver du inte göra något."
 
-#~ msgid ""
-#~ "For more information, please visit <a href='https://support.mozilla."
-#~ "org'>Mozilla Support</a>"
-#~ msgstr ""
-#~ "För mer information, besök <a href='https://support.mozilla.org'>Mozilla "
-#~ "Support</a>"
+#: templates/reset.html:6 templates/unlock.html:5 templates/verify.html:6
+msgid ""
+"For more information, please visit <a href='https://support.mozilla."
+"org'>Mozilla Support</a>"
+msgstr ""
+"För mer information, besök <a href='https://support.mozilla.org'>Mozilla "
+"Support</a>"
 
-#~ msgid "Reset password:"
-#~ msgstr "Återställ lösenordet:"
+#: templates/reset.txt:3
+msgid "Reset password:"
+msgstr "Återställ lösenordet:"
 
-#~ msgid "For more information, please visit https://support.mozilla.org"
-#~ msgstr "För mer information, besök https://support.mozilla.org"
+#: templates/reset.txt:5 templates/unlock.txt:4 templates/verify.txt:5
+msgid "For more information, please visit https://support.mozilla.org"
+msgstr "För mer information, besök https://support.mozilla.org"
+
+#: templates/unlock.html:2 templates/unlock.txt:1
+msgid ""
+"For security reasons your Firefox Account was put on lockdown. To perform "
+"account-level activities, please click the link to re-verify your account "
+"now."
+msgstr ""
+
+#: templates/unlock.html:3
+msgid "Verify account"
+msgstr ""
+
+#: templates/unlock.txt:2
+msgid "Verify account:"
+msgstr ""
+
+#: templates/verify.html:2 templates/verify.txt:1
+msgid "Almost there"
+msgstr ""
+
+#: templates/verify.html:3 templates/verify.txt:2
+msgid "%(email)s, you're one click away from verifying your Firefox Account."
+msgstr "%(email)s, du är ett klick ifrån att verifiera ditt Firefox-konto."
+
+#: templates/verify.html:4
+msgid "Verify"
+msgstr "Verifiera"
+
+#: templates/verify.txt:3
+msgid "Verify:"
+msgstr "Verifiera:"
 
 #~ msgid "Congratulations!"
 #~ msgstr "Grattis!"
-
-#~ msgid ""
-#~ "%(email)s, you're one click away from verifying your Firefox Account."
-#~ msgstr "%(email)s, du är ett klick ifrån att verifiera ditt Firefox-konto."
-
-#~ msgid "Verify"
-#~ msgstr "Verifiera"
-
-#~ msgid "Verify:"
-#~ msgstr "Verifiera:"
 
 #~ msgid "Verify your account"
 #~ msgstr "Verifiera ditt konto"

--- a/locale/ta/LC_MESSAGES/server.po
+++ b/locale/ta/LC_MESSAGES/server.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-02-20 19:15+0000\n"
+"POT-Creation-Date: 2015-02-25 18:58+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,7 +17,8 @@ msgstr ""
 #: server/templates/pages/src/503.html:1
 #: server/templates/pages/src/index.html:1
 #: server/templates/pages/src/privacy.html:1
-#: server/templates/pages/src/terms.html:1
+#: server/templates/pages/src/terms.html:1 templates/reset.html:1
+#: templates/unlock.html:1 templates/verify.html:1
 msgid "Firefox Accounts"
 msgstr ""
 
@@ -89,4 +90,68 @@ msgstr ""
 #: server/templates/pages/src/terms.html:2
 #: server/templates/pages/src/terms.html:5
 msgid "Terms of Service"
+msgstr ""
+
+#: templates/reset.html:2 templates/reset.txt:1
+msgid "Are you sure?"
+msgstr ""
+
+#: templates/reset.html:3 templates/reset.txt:2
+msgid "Please confirm that you'd like to reset the password for %(email)s."
+msgstr ""
+
+#: templates/reset.html:4
+msgid "Reset password"
+msgstr ""
+
+#: templates/reset.html:5 templates/reset.txt:4 templates/unlock.html:4
+#: templates/unlock.txt:3 templates/verify.html:5 templates/verify.txt:4
+msgid ""
+"This is an automated email; if you received it in error, no action is "
+"required."
+msgstr ""
+
+#: templates/reset.html:6 templates/unlock.html:5 templates/verify.html:6
+msgid ""
+"For more information, please visit <a href='https://support.mozilla."
+"org'>Mozilla Support</a>"
+msgstr ""
+
+#: templates/reset.txt:3
+msgid "Reset password:"
+msgstr ""
+
+#: templates/reset.txt:5 templates/unlock.txt:4 templates/verify.txt:5
+msgid "For more information, please visit https://support.mozilla.org"
+msgstr ""
+
+#: templates/unlock.html:2 templates/unlock.txt:1
+msgid ""
+"For security reasons your Firefox Account was put on lockdown. To perform "
+"account-level activities, please click the link to re-verify your account "
+"now."
+msgstr ""
+
+#: templates/unlock.html:3
+msgid "Verify account"
+msgstr ""
+
+#: templates/unlock.txt:2
+msgid "Verify account:"
+msgstr ""
+
+#: templates/verify.html:2 templates/verify.txt:1
+msgid "Almost there"
+msgstr ""
+
+#: templates/verify.html:3 templates/verify.txt:2
+msgid "%(email)s, you're one click away from verifying your Firefox Account."
+msgstr ""
+
+#: templates/verify.html:4
+msgid "Verify"
+msgstr ""
+
+#: templates/verify.txt:3
+msgid "Verify:"
 msgstr ""

--- a/locale/te/LC_MESSAGES/server.po
+++ b/locale/te/LC_MESSAGES/server.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-02-20 19:15+0000\n"
+"POT-Creation-Date: 2015-02-25 18:58+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "Language: \n"
@@ -15,7 +15,8 @@ msgstr ""
 #: server/templates/pages/src/503.html:1
 #: server/templates/pages/src/index.html:1
 #: server/templates/pages/src/privacy.html:1
-#: server/templates/pages/src/terms.html:1
+#: server/templates/pages/src/terms.html:1 templates/reset.html:1
+#: templates/unlock.html:1 templates/verify.html:1
 msgid "Firefox Accounts"
 msgstr ""
 
@@ -87,4 +88,68 @@ msgstr ""
 #: server/templates/pages/src/terms.html:2
 #: server/templates/pages/src/terms.html:5
 msgid "Terms of Service"
+msgstr ""
+
+#: templates/reset.html:2 templates/reset.txt:1
+msgid "Are you sure?"
+msgstr ""
+
+#: templates/reset.html:3 templates/reset.txt:2
+msgid "Please confirm that you'd like to reset the password for %(email)s."
+msgstr ""
+
+#: templates/reset.html:4
+msgid "Reset password"
+msgstr ""
+
+#: templates/reset.html:5 templates/reset.txt:4 templates/unlock.html:4
+#: templates/unlock.txt:3 templates/verify.html:5 templates/verify.txt:4
+msgid ""
+"This is an automated email; if you received it in error, no action is "
+"required."
+msgstr ""
+
+#: templates/reset.html:6 templates/unlock.html:5 templates/verify.html:6
+msgid ""
+"For more information, please visit <a href='https://support.mozilla."
+"org'>Mozilla Support</a>"
+msgstr ""
+
+#: templates/reset.txt:3
+msgid "Reset password:"
+msgstr ""
+
+#: templates/reset.txt:5 templates/unlock.txt:4 templates/verify.txt:5
+msgid "For more information, please visit https://support.mozilla.org"
+msgstr ""
+
+#: templates/unlock.html:2 templates/unlock.txt:1
+msgid ""
+"For security reasons your Firefox Account was put on lockdown. To perform "
+"account-level activities, please click the link to re-verify your account "
+"now."
+msgstr ""
+
+#: templates/unlock.html:3
+msgid "Verify account"
+msgstr ""
+
+#: templates/unlock.txt:2
+msgid "Verify account:"
+msgstr ""
+
+#: templates/verify.html:2 templates/verify.txt:1
+msgid "Almost there"
+msgstr ""
+
+#: templates/verify.html:3 templates/verify.txt:2
+msgid "%(email)s, you're one click away from verifying your Firefox Account."
+msgstr ""
+
+#: templates/verify.html:4
+msgid "Verify"
+msgstr ""
+
+#: templates/verify.txt:3
+msgid "Verify:"
 msgstr ""

--- a/locale/templates/LC_MESSAGES/server.pot
+++ b/locale/templates/LC_MESSAGES/server.pot
@@ -8,7 +8,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2015-02-20 19:15+0000\n"
+"POT-Creation-Date: 2015-02-25 18:58+0000\n"
 
 #: server/templates/pages/src/400.html:1
 #: server/templates/pages/src/404.html:1
@@ -18,6 +18,9 @@ msgstr ""
 #: server/templates/pages/src/index.html:1
 #: server/templates/pages/src/privacy.html:1
 #: server/templates/pages/src/terms.html:1
+#: templates/reset.html:1
+#: templates/unlock.html:1
+#: templates/verify.html:1
 msgid "Firefox Accounts"
 msgstr ""
 
@@ -93,4 +96,81 @@ msgstr ""
 #: server/templates/pages/src/terms.html:2
 #: server/templates/pages/src/terms.html:5
 msgid "Terms of Service"
+msgstr ""
+
+#: templates/reset.html:2
+#: templates/reset.txt:1
+msgid "Are you sure?"
+msgstr ""
+
+#: templates/reset.html:3
+#: templates/reset.txt:2
+msgid "Please confirm that you'd like to reset the password for %(email)s."
+msgstr ""
+
+#: templates/reset.html:4
+msgid "Reset password"
+msgstr ""
+
+#: templates/reset.html:5
+#: templates/reset.txt:4
+#: templates/unlock.html:4
+#: templates/unlock.txt:3
+#: templates/verify.html:5
+#: templates/verify.txt:4
+msgid ""
+"This is an automated email; if you received it in error, no action is "
+"required."
+msgstr ""
+
+#: templates/reset.html:6
+#: templates/unlock.html:5
+#: templates/verify.html:6
+msgid ""
+"For more information, please visit <a "
+"href='https://support.mozilla.org'>Mozilla Support</a>"
+msgstr ""
+
+#: templates/reset.txt:3
+msgid "Reset password:"
+msgstr ""
+
+#: templates/reset.txt:5
+#: templates/unlock.txt:4
+#: templates/verify.txt:5
+msgid "For more information, please visit https://support.mozilla.org"
+msgstr ""
+
+#: templates/unlock.html:2
+#: templates/unlock.txt:1
+msgid ""
+"For security reasons your Firefox Account was put on lockdown. To perform "
+"account-level activities, please click the link to re-verify your account "
+"now."
+msgstr ""
+
+#: templates/unlock.html:3
+msgid "Verify account"
+msgstr ""
+
+#: templates/unlock.txt:2
+msgid "Verify account:"
+msgstr ""
+
+#: templates/verify.html:2
+#: templates/verify.txt:1
+msgid "Almost there"
+msgstr ""
+
+#: templates/verify.html:3
+#: templates/verify.txt:2
+msgid "%(email)s, you're one click away from verifying your Firefox Account."
+msgstr ""
+
+#: templates/verify.html:4
+msgid "Verify"
+msgstr ""
+
+#: templates/verify.txt:3
+msgid "Verify:"
 msgstr ""

--- a/locale/th/LC_MESSAGES/server.po
+++ b/locale/th/LC_MESSAGES/server.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-02-20 19:15+0000\n"
+"POT-Creation-Date: 2015-02-25 18:58+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "Language: \n"
@@ -15,7 +15,8 @@ msgstr ""
 #: server/templates/pages/src/503.html:1
 #: server/templates/pages/src/index.html:1
 #: server/templates/pages/src/privacy.html:1
-#: server/templates/pages/src/terms.html:1
+#: server/templates/pages/src/terms.html:1 templates/reset.html:1
+#: templates/unlock.html:1 templates/verify.html:1
 msgid "Firefox Accounts"
 msgstr ""
 
@@ -87,4 +88,68 @@ msgstr ""
 #: server/templates/pages/src/terms.html:2
 #: server/templates/pages/src/terms.html:5
 msgid "Terms of Service"
+msgstr ""
+
+#: templates/reset.html:2 templates/reset.txt:1
+msgid "Are you sure?"
+msgstr ""
+
+#: templates/reset.html:3 templates/reset.txt:2
+msgid "Please confirm that you'd like to reset the password for %(email)s."
+msgstr ""
+
+#: templates/reset.html:4
+msgid "Reset password"
+msgstr ""
+
+#: templates/reset.html:5 templates/reset.txt:4 templates/unlock.html:4
+#: templates/unlock.txt:3 templates/verify.html:5 templates/verify.txt:4
+msgid ""
+"This is an automated email; if you received it in error, no action is "
+"required."
+msgstr ""
+
+#: templates/reset.html:6 templates/unlock.html:5 templates/verify.html:6
+msgid ""
+"For more information, please visit <a href='https://support.mozilla."
+"org'>Mozilla Support</a>"
+msgstr ""
+
+#: templates/reset.txt:3
+msgid "Reset password:"
+msgstr ""
+
+#: templates/reset.txt:5 templates/unlock.txt:4 templates/verify.txt:5
+msgid "For more information, please visit https://support.mozilla.org"
+msgstr ""
+
+#: templates/unlock.html:2 templates/unlock.txt:1
+msgid ""
+"For security reasons your Firefox Account was put on lockdown. To perform "
+"account-level activities, please click the link to re-verify your account "
+"now."
+msgstr ""
+
+#: templates/unlock.html:3
+msgid "Verify account"
+msgstr ""
+
+#: templates/unlock.txt:2
+msgid "Verify account:"
+msgstr ""
+
+#: templates/verify.html:2 templates/verify.txt:1
+msgid "Almost there"
+msgstr ""
+
+#: templates/verify.html:3 templates/verify.txt:2
+msgid "%(email)s, you're one click away from verifying your Firefox Account."
+msgstr ""
+
+#: templates/verify.html:4
+msgid "Verify"
+msgstr ""
+
+#: templates/verify.txt:3
+msgid "Verify:"
 msgstr ""

--- a/locale/tr/LC_MESSAGES/server.po
+++ b/locale/tr/LC_MESSAGES/server.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-02-20 19:15+0000\n"
+"POT-Creation-Date: 2015-02-25 18:58+0000\n"
 "PO-Revision-Date: 2014-10-31 10:40+0000\n"
 "Last-Translator: Selim <selim@sum.lu>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -19,7 +19,8 @@ msgstr ""
 #: server/templates/pages/src/503.html:1
 #: server/templates/pages/src/index.html:1
 #: server/templates/pages/src/privacy.html:1
-#: server/templates/pages/src/terms.html:1
+#: server/templates/pages/src/terms.html:1 templates/reset.html:1
+#: templates/unlock.html:1 templates/verify.html:1
 msgid "Firefox Accounts"
 msgstr "Firefox Hesapları"
 
@@ -102,50 +103,79 @@ msgstr "Firefox bulut servisleri"
 msgid "Terms of Service"
 msgstr "Hizmet Koşulları"
 
-#~ msgid "Are you sure?"
-#~ msgstr "Emin misiniz?"
+#: templates/reset.html:2 templates/reset.txt:1
+msgid "Are you sure?"
+msgstr "Emin misiniz?"
 
-#~ msgid "Please confirm that you'd like to reset the password for %(email)s."
-#~ msgstr ""
-#~ "Lütfen %(email)s adresinin parolasını sıfırlamak istediğiniz onaylayın."
+#: templates/reset.html:3 templates/reset.txt:2
+msgid "Please confirm that you'd like to reset the password for %(email)s."
+msgstr ""
+"Lütfen %(email)s adresinin parolasını sıfırlamak istediğiniz onaylayın."
 
-#~ msgid "Reset password"
-#~ msgstr "Parolanızı sıfırlayın"
+#: templates/reset.html:4
+msgid "Reset password"
+msgstr "Parolanızı sıfırlayın"
 
-#~ msgid ""
-#~ "This is an automated email; if you received it in error, no action is "
-#~ "required."
-#~ msgstr ""
-#~ "Bu e-posta otomatik olarak gönderilmiştir. Hatalı olduğunu düşünüyorsanız "
-#~ "bir şey yapmanıza gerek yoktur."
+#: templates/reset.html:5 templates/reset.txt:4 templates/unlock.html:4
+#: templates/unlock.txt:3 templates/verify.html:5 templates/verify.txt:4
+msgid ""
+"This is an automated email; if you received it in error, no action is "
+"required."
+msgstr ""
+"Bu e-posta otomatik olarak gönderilmiştir. Hatalı olduğunu düşünüyorsanız "
+"bir şey yapmanıza gerek yoktur."
 
-#~ msgid ""
-#~ "For more information, please visit <a href='https://support.mozilla."
-#~ "org'>Mozilla Support</a>"
-#~ msgstr ""
-#~ "Daha fazla bilgi için lütfen <a href='https://support.mozilla."
-#~ "org'>Mozilla Destek</a>'i ziyaret edin"
+#: templates/reset.html:6 templates/unlock.html:5 templates/verify.html:6
+msgid ""
+"For more information, please visit <a href='https://support.mozilla."
+"org'>Mozilla Support</a>"
+msgstr ""
+"Daha fazla bilgi için lütfen <a href='https://support.mozilla.org'>Mozilla "
+"Destek</a>'i ziyaret edin"
 
-#~ msgid "Reset password:"
-#~ msgstr "Parolanızı sıfırlayın:"
+#: templates/reset.txt:3
+msgid "Reset password:"
+msgstr "Parolanızı sıfırlayın:"
 
-#~ msgid "For more information, please visit https://support.mozilla.org"
-#~ msgstr ""
-#~ "Daha fazla bilgi için lütfen https://support.mozilla.org adresini ziyaret "
-#~ "edin"
+#: templates/reset.txt:5 templates/unlock.txt:4 templates/verify.txt:5
+msgid "For more information, please visit https://support.mozilla.org"
+msgstr ""
+"Daha fazla bilgi için lütfen https://support.mozilla.org adresini ziyaret "
+"edin"
+
+#: templates/unlock.html:2 templates/unlock.txt:1
+msgid ""
+"For security reasons your Firefox Account was put on lockdown. To perform "
+"account-level activities, please click the link to re-verify your account "
+"now."
+msgstr ""
+
+#: templates/unlock.html:3
+msgid "Verify account"
+msgstr ""
+
+#: templates/unlock.txt:2
+msgid "Verify account:"
+msgstr ""
+
+#: templates/verify.html:2 templates/verify.txt:1
+msgid "Almost there"
+msgstr ""
+
+#: templates/verify.html:3 templates/verify.txt:2
+msgid "%(email)s, you're one click away from verifying your Firefox Account."
+msgstr "%(email)s, Firefox hesabınızı doğrulamanıza bir tıklama kaldı."
+
+#: templates/verify.html:4
+msgid "Verify"
+msgstr "Doğrula"
+
+#: templates/verify.txt:3
+msgid "Verify:"
+msgstr "Doğrula:"
 
 #~ msgid "Congratulations!"
 #~ msgstr "Tebrikler!"
-
-#~ msgid ""
-#~ "%(email)s, you're one click away from verifying your Firefox Account."
-#~ msgstr "%(email)s, Firefox hesabınızı doğrulamanıza bir tıklama kaldı."
-
-#~ msgid "Verify"
-#~ msgstr "Doğrula"
-
-#~ msgid "Verify:"
-#~ msgstr "Doğrula:"
 
 #~ msgid "Verify your account"
 #~ msgstr "Hesabınızı doğrulayın"

--- a/locale/uk/LC_MESSAGES/server.po
+++ b/locale/uk/LC_MESSAGES/server.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-02-20 19:15+0000\n"
+"POT-Creation-Date: 2015-02-25 18:58+0000\n"
 "PO-Revision-Date: 2015-02-21 19:00+0000\n"
 "Last-Translator: Artem <a.polivanchuk@outlook.com>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -10,8 +10,8 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%"
-"10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
+"%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
 "X-Generator: Pootle 2.5.0\n"
 "X-POOTLE-MTIME: 1424545257.0\n"
 
@@ -20,7 +20,8 @@ msgstr ""
 #: server/templates/pages/src/503.html:1
 #: server/templates/pages/src/index.html:1
 #: server/templates/pages/src/privacy.html:1
-#: server/templates/pages/src/terms.html:1
+#: server/templates/pages/src/terms.html:1 templates/reset.html:1
+#: templates/unlock.html:1 templates/verify.html:1
 msgid "Firefox Accounts"
 msgstr "Облікові записи Firefox"
 
@@ -103,50 +104,78 @@ msgstr "Хмарні сервіси Firefox"
 msgid "Terms of Service"
 msgstr "Умови надання послуг"
 
-#~ msgid "Are you sure?"
-#~ msgstr "Ви впевнені?"
+#: templates/reset.html:2 templates/reset.txt:1
+msgid "Are you sure?"
+msgstr "Ви впевнені?"
 
-#~ msgid "Please confirm that you'd like to reset the password for %(email)s."
-#~ msgstr "Підтвердіть, що ви бажаєте відновити пароль для %(email)s."
+#: templates/reset.html:3 templates/reset.txt:2
+msgid "Please confirm that you'd like to reset the password for %(email)s."
+msgstr "Підтвердіть, що ви бажаєте відновити пароль для %(email)s."
 
-#~ msgid "Reset password"
-#~ msgstr "Відновити пароль"
+#: templates/reset.html:4
+msgid "Reset password"
+msgstr "Відновити пароль"
 
-#~ msgid ""
-#~ "This is an automated email; if you received it in error, no action is "
-#~ "required."
-#~ msgstr ""
-#~ "Це автоматичне повідомлення; якщо ви отримали його помилково, не реагуйте "
-#~ "на нього."
+#: templates/reset.html:5 templates/reset.txt:4 templates/unlock.html:4
+#: templates/unlock.txt:3 templates/verify.html:5 templates/verify.txt:4
+msgid ""
+"This is an automated email; if you received it in error, no action is "
+"required."
+msgstr ""
+"Це автоматичне повідомлення; якщо ви отримали його помилково, не реагуйте на "
+"нього."
 
-#~ msgid ""
-#~ "For more information, please visit <a href='https://support.mozilla."
-#~ "org'>Mozilla Support</a>"
-#~ msgstr ""
-#~ "Щоб отримати більше інформації, відвідайте <a href='https://support."
-#~ "mozilla.org'>Підтримку Mozilla</a>"
+#: templates/reset.html:6 templates/unlock.html:5 templates/verify.html:6
+msgid ""
+"For more information, please visit <a href='https://support.mozilla."
+"org'>Mozilla Support</a>"
+msgstr ""
+"Щоб отримати більше інформації, відвідайте <a href='https://support.mozilla."
+"org'>Підтримку Mozilla</a>"
 
-#~ msgid "Reset password:"
-#~ msgstr "Відновити пароль:"
+#: templates/reset.txt:3
+msgid "Reset password:"
+msgstr "Відновити пароль:"
 
-#~ msgid "For more information, please visit https://support.mozilla.org"
-#~ msgstr ""
-#~ "Щоб отримати більше інформації, відвідайте https://support.mozilla.org"
+#: templates/reset.txt:5 templates/unlock.txt:4 templates/verify.txt:5
+msgid "For more information, please visit https://support.mozilla.org"
+msgstr "Щоб отримати більше інформації, відвідайте https://support.mozilla.org"
+
+#: templates/unlock.html:2 templates/unlock.txt:1
+msgid ""
+"For security reasons your Firefox Account was put on lockdown. To perform "
+"account-level activities, please click the link to re-verify your account "
+"now."
+msgstr ""
+
+#: templates/unlock.html:3
+msgid "Verify account"
+msgstr ""
+
+#: templates/unlock.txt:2
+msgid "Verify account:"
+msgstr ""
+
+#: templates/verify.html:2 templates/verify.txt:1
+msgid "Almost there"
+msgstr ""
+
+#: templates/verify.html:3 templates/verify.txt:2
+msgid "%(email)s, you're one click away from verifying your Firefox Account."
+msgstr ""
+"%(email)s, залишився один крок до підтвердження вашого облікового запису "
+"Firefox."
+
+#: templates/verify.html:4
+msgid "Verify"
+msgstr "Підтвердити"
+
+#: templates/verify.txt:3
+msgid "Verify:"
+msgstr "Підтвердити:"
 
 #~ msgid "Congratulations!"
 #~ msgstr "Вітаємо!"
-
-#~ msgid ""
-#~ "%(email)s, you're one click away from verifying your Firefox Account."
-#~ msgstr ""
-#~ "%(email)s, залишився один крок до підтвердження вашого облікового запису "
-#~ "Firefox."
-
-#~ msgid "Verify"
-#~ msgstr "Підтвердити"
-
-#~ msgid "Verify:"
-#~ msgstr "Підтвердити:"
 
 #~ msgid "Verify your account"
 #~ msgstr "Підтвердити свій обліковий запис"

--- a/locale/ur/LC_MESSAGES/server.po
+++ b/locale/ur/LC_MESSAGES/server.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-02-20 19:15+0000\n"
+"POT-Creation-Date: 2015-02-25 18:58+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "Language: \n"
@@ -15,7 +15,8 @@ msgstr ""
 #: server/templates/pages/src/503.html:1
 #: server/templates/pages/src/index.html:1
 #: server/templates/pages/src/privacy.html:1
-#: server/templates/pages/src/terms.html:1
+#: server/templates/pages/src/terms.html:1 templates/reset.html:1
+#: templates/unlock.html:1 templates/verify.html:1
 msgid "Firefox Accounts"
 msgstr ""
 
@@ -87,4 +88,68 @@ msgstr ""
 #: server/templates/pages/src/terms.html:2
 #: server/templates/pages/src/terms.html:5
 msgid "Terms of Service"
+msgstr ""
+
+#: templates/reset.html:2 templates/reset.txt:1
+msgid "Are you sure?"
+msgstr ""
+
+#: templates/reset.html:3 templates/reset.txt:2
+msgid "Please confirm that you'd like to reset the password for %(email)s."
+msgstr ""
+
+#: templates/reset.html:4
+msgid "Reset password"
+msgstr ""
+
+#: templates/reset.html:5 templates/reset.txt:4 templates/unlock.html:4
+#: templates/unlock.txt:3 templates/verify.html:5 templates/verify.txt:4
+msgid ""
+"This is an automated email; if you received it in error, no action is "
+"required."
+msgstr ""
+
+#: templates/reset.html:6 templates/unlock.html:5 templates/verify.html:6
+msgid ""
+"For more information, please visit <a href='https://support.mozilla."
+"org'>Mozilla Support</a>"
+msgstr ""
+
+#: templates/reset.txt:3
+msgid "Reset password:"
+msgstr ""
+
+#: templates/reset.txt:5 templates/unlock.txt:4 templates/verify.txt:5
+msgid "For more information, please visit https://support.mozilla.org"
+msgstr ""
+
+#: templates/unlock.html:2 templates/unlock.txt:1
+msgid ""
+"For security reasons your Firefox Account was put on lockdown. To perform "
+"account-level activities, please click the link to re-verify your account "
+"now."
+msgstr ""
+
+#: templates/unlock.html:3
+msgid "Verify account"
+msgstr ""
+
+#: templates/unlock.txt:2
+msgid "Verify account:"
+msgstr ""
+
+#: templates/verify.html:2 templates/verify.txt:1
+msgid "Almost there"
+msgstr ""
+
+#: templates/verify.html:3 templates/verify.txt:2
+msgid "%(email)s, you're one click away from verifying your Firefox Account."
+msgstr ""
+
+#: templates/verify.html:4
+msgid "Verify"
+msgstr ""
+
+#: templates/verify.txt:3
+msgid "Verify:"
 msgstr ""

--- a/locale/vi/LC_MESSAGES/server.po
+++ b/locale/vi/LC_MESSAGES/server.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-02-20 19:15+0000\n"
+"POT-Creation-Date: 2015-02-25 18:58+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "Language: \n"
@@ -15,7 +15,8 @@ msgstr ""
 #: server/templates/pages/src/503.html:1
 #: server/templates/pages/src/index.html:1
 #: server/templates/pages/src/privacy.html:1
-#: server/templates/pages/src/terms.html:1
+#: server/templates/pages/src/terms.html:1 templates/reset.html:1
+#: templates/unlock.html:1 templates/verify.html:1
 msgid "Firefox Accounts"
 msgstr ""
 
@@ -87,4 +88,68 @@ msgstr ""
 #: server/templates/pages/src/terms.html:2
 #: server/templates/pages/src/terms.html:5
 msgid "Terms of Service"
+msgstr ""
+
+#: templates/reset.html:2 templates/reset.txt:1
+msgid "Are you sure?"
+msgstr ""
+
+#: templates/reset.html:3 templates/reset.txt:2
+msgid "Please confirm that you'd like to reset the password for %(email)s."
+msgstr ""
+
+#: templates/reset.html:4
+msgid "Reset password"
+msgstr ""
+
+#: templates/reset.html:5 templates/reset.txt:4 templates/unlock.html:4
+#: templates/unlock.txt:3 templates/verify.html:5 templates/verify.txt:4
+msgid ""
+"This is an automated email; if you received it in error, no action is "
+"required."
+msgstr ""
+
+#: templates/reset.html:6 templates/unlock.html:5 templates/verify.html:6
+msgid ""
+"For more information, please visit <a href='https://support.mozilla."
+"org'>Mozilla Support</a>"
+msgstr ""
+
+#: templates/reset.txt:3
+msgid "Reset password:"
+msgstr ""
+
+#: templates/reset.txt:5 templates/unlock.txt:4 templates/verify.txt:5
+msgid "For more information, please visit https://support.mozilla.org"
+msgstr ""
+
+#: templates/unlock.html:2 templates/unlock.txt:1
+msgid ""
+"For security reasons your Firefox Account was put on lockdown. To perform "
+"account-level activities, please click the link to re-verify your account "
+"now."
+msgstr ""
+
+#: templates/unlock.html:3
+msgid "Verify account"
+msgstr ""
+
+#: templates/unlock.txt:2
+msgid "Verify account:"
+msgstr ""
+
+#: templates/verify.html:2 templates/verify.txt:1
+msgid "Almost there"
+msgstr ""
+
+#: templates/verify.html:3 templates/verify.txt:2
+msgid "%(email)s, you're one click away from verifying your Firefox Account."
+msgstr ""
+
+#: templates/verify.html:4
+msgid "Verify"
+msgstr ""
+
+#: templates/verify.txt:3
+msgid "Verify:"
 msgstr ""

--- a/locale/win32/LC_MESSAGES/server.po
+++ b/locale/win32/LC_MESSAGES/server.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-02-20 19:15+0000\n"
+"POT-Creation-Date: 2015-02-25 18:58+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "Language: \n"
@@ -15,7 +15,8 @@ msgstr ""
 #: server/templates/pages/src/503.html:1
 #: server/templates/pages/src/index.html:1
 #: server/templates/pages/src/privacy.html:1
-#: server/templates/pages/src/terms.html:1
+#: server/templates/pages/src/terms.html:1 templates/reset.html:1
+#: templates/unlock.html:1 templates/verify.html:1
 msgid "Firefox Accounts"
 msgstr ""
 
@@ -87,4 +88,68 @@ msgstr ""
 #: server/templates/pages/src/terms.html:2
 #: server/templates/pages/src/terms.html:5
 msgid "Terms of Service"
+msgstr ""
+
+#: templates/reset.html:2 templates/reset.txt:1
+msgid "Are you sure?"
+msgstr ""
+
+#: templates/reset.html:3 templates/reset.txt:2
+msgid "Please confirm that you'd like to reset the password for %(email)s."
+msgstr ""
+
+#: templates/reset.html:4
+msgid "Reset password"
+msgstr ""
+
+#: templates/reset.html:5 templates/reset.txt:4 templates/unlock.html:4
+#: templates/unlock.txt:3 templates/verify.html:5 templates/verify.txt:4
+msgid ""
+"This is an automated email; if you received it in error, no action is "
+"required."
+msgstr ""
+
+#: templates/reset.html:6 templates/unlock.html:5 templates/verify.html:6
+msgid ""
+"For more information, please visit <a href='https://support.mozilla."
+"org'>Mozilla Support</a>"
+msgstr ""
+
+#: templates/reset.txt:3
+msgid "Reset password:"
+msgstr ""
+
+#: templates/reset.txt:5 templates/unlock.txt:4 templates/verify.txt:5
+msgid "For more information, please visit https://support.mozilla.org"
+msgstr ""
+
+#: templates/unlock.html:2 templates/unlock.txt:1
+msgid ""
+"For security reasons your Firefox Account was put on lockdown. To perform "
+"account-level activities, please click the link to re-verify your account "
+"now."
+msgstr ""
+
+#: templates/unlock.html:3
+msgid "Verify account"
+msgstr ""
+
+#: templates/unlock.txt:2
+msgid "Verify account:"
+msgstr ""
+
+#: templates/verify.html:2 templates/verify.txt:1
+msgid "Almost there"
+msgstr ""
+
+#: templates/verify.html:3 templates/verify.txt:2
+msgid "%(email)s, you're one click away from verifying your Firefox Account."
+msgstr ""
+
+#: templates/verify.html:4
+msgid "Verify"
+msgstr ""
+
+#: templates/verify.txt:3
+msgid "Verify:"
 msgstr ""

--- a/locale/xh/LC_MESSAGES/server.po
+++ b/locale/xh/LC_MESSAGES/server.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-02-20 19:15+0000\n"
+"POT-Creation-Date: 2015-02-25 18:58+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "Language: \n"
@@ -15,7 +15,8 @@ msgstr ""
 #: server/templates/pages/src/503.html:1
 #: server/templates/pages/src/index.html:1
 #: server/templates/pages/src/privacy.html:1
-#: server/templates/pages/src/terms.html:1
+#: server/templates/pages/src/terms.html:1 templates/reset.html:1
+#: templates/unlock.html:1 templates/verify.html:1
 msgid "Firefox Accounts"
 msgstr ""
 
@@ -87,4 +88,68 @@ msgstr ""
 #: server/templates/pages/src/terms.html:2
 #: server/templates/pages/src/terms.html:5
 msgid "Terms of Service"
+msgstr ""
+
+#: templates/reset.html:2 templates/reset.txt:1
+msgid "Are you sure?"
+msgstr ""
+
+#: templates/reset.html:3 templates/reset.txt:2
+msgid "Please confirm that you'd like to reset the password for %(email)s."
+msgstr ""
+
+#: templates/reset.html:4
+msgid "Reset password"
+msgstr ""
+
+#: templates/reset.html:5 templates/reset.txt:4 templates/unlock.html:4
+#: templates/unlock.txt:3 templates/verify.html:5 templates/verify.txt:4
+msgid ""
+"This is an automated email; if you received it in error, no action is "
+"required."
+msgstr ""
+
+#: templates/reset.html:6 templates/unlock.html:5 templates/verify.html:6
+msgid ""
+"For more information, please visit <a href='https://support.mozilla."
+"org'>Mozilla Support</a>"
+msgstr ""
+
+#: templates/reset.txt:3
+msgid "Reset password:"
+msgstr ""
+
+#: templates/reset.txt:5 templates/unlock.txt:4 templates/verify.txt:5
+msgid "For more information, please visit https://support.mozilla.org"
+msgstr ""
+
+#: templates/unlock.html:2 templates/unlock.txt:1
+msgid ""
+"For security reasons your Firefox Account was put on lockdown. To perform "
+"account-level activities, please click the link to re-verify your account "
+"now."
+msgstr ""
+
+#: templates/unlock.html:3
+msgid "Verify account"
+msgstr ""
+
+#: templates/unlock.txt:2
+msgid "Verify account:"
+msgstr ""
+
+#: templates/verify.html:2 templates/verify.txt:1
+msgid "Almost there"
+msgstr ""
+
+#: templates/verify.html:3 templates/verify.txt:2
+msgid "%(email)s, you're one click away from verifying your Firefox Account."
+msgstr ""
+
+#: templates/verify.html:4
+msgid "Verify"
+msgstr ""
+
+#: templates/verify.txt:3
+msgid "Verify:"
 msgstr ""

--- a/locale/zh_CN/LC_MESSAGES/server.po
+++ b/locale/zh_CN/LC_MESSAGES/server.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2014-11-10 18:39+0000\n"
+"POT-Creation-Date: 2015-02-25 18:58+0000\n"
 "PO-Revision-Date: 2014-10-11 23:16+0000\n"
 "Last-Translator: yfdyh000 <yfdyh000@gmail.com>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -14,14 +14,19 @@ msgstr ""
 "X-Generator: Pootle 2.5.0\n"
 "X-POOTLE-MTIME: 1413069388.0\n"
 
-#: server/templates/pages/src/404.html:1 server/templates/pages/src/500.html:1
+#: server/templates/pages/src/400.html:1 server/templates/pages/src/404.html:1
+#: server/templates/pages/src/500.html:1 server/templates/pages/src/502.html:1
 #: server/templates/pages/src/503.html:1
 #: server/templates/pages/src/index.html:1
 #: server/templates/pages/src/privacy.html:1
-#: server/templates/pages/src/terms.html:1 server/templates/email/reset.html:1
-#: server/templates/email/verify.html:1
+#: server/templates/pages/src/terms.html:1 templates/reset.html:1
+#: templates/unlock.html:1 templates/verify.html:1
 msgid "Firefox Accounts"
 msgstr "Firefox 账号"
+
+#: server/templates/pages/src/400.html:2
+msgid "Bad Request"
+msgstr ""
 
 #: server/templates/pages/src/404.html:2
 msgid "Page not found"
@@ -34,7 +39,7 @@ msgid ""
 msgstr "找不到您要打开的页面，我们已收到此通知并会修复出现故障的链接。"
 
 #: server/templates/pages/src/404.html:4 server/templates/pages/src/500.html:4
-#: server/templates/pages/src/503.html:4
+#: server/templates/pages/src/502.html:4 server/templates/pages/src/503.html:4
 msgid "Home"
 msgstr "首页"
 
@@ -42,11 +47,15 @@ msgstr "首页"
 msgid "500 Error"
 msgstr "500 错误"
 
-#: server/templates/pages/src/500.html:3
+#: server/templates/pages/src/500.html:3 server/templates/pages/src/502.html:3
 msgid ""
 "Oh dear, something went wrong there. We've been notified and will get "
 "working on a fix."
 msgstr "噢抱歉，出了点问题。我们已经记录下来并将进行修复。"
+
+#: server/templates/pages/src/502.html:2
+msgid "502 Error"
+msgstr ""
 
 #: server/templates/pages/src/503.html:2
 msgid "Server busy, try again soon"
@@ -87,20 +96,20 @@ msgstr "Firefox 云服务"
 msgid "Terms of Service"
 msgstr "服务条款"
 
-#: server/templates/email/reset.html:2 server/templates/email/reset.txt:1
+#: templates/reset.html:2 templates/reset.txt:1
 msgid "Are you sure?"
 msgstr "您确定？"
 
-#: server/templates/email/reset.html:3 server/templates/email/reset.txt:2
+#: templates/reset.html:3 templates/reset.txt:2
 msgid "Please confirm that you'd like to reset the password for %(email)s."
 msgstr "请确认您希望重置 %(email)s 的密码。"
 
-#: server/templates/email/reset.html:4
+#: templates/reset.html:4
 msgid "Reset password"
 msgstr "重置密码"
 
-#: server/templates/email/reset.html:5 server/templates/email/reset.txt:4
-#: server/templates/email/verify.html:5 server/templates/email/verify.txt:4
+#: templates/reset.html:5 templates/reset.txt:4 templates/unlock.html:4
+#: templates/unlock.txt:3 templates/verify.html:5 templates/verify.txt:4
 msgid ""
 "This is an automated email; if you received it in error, no action is "
 "required."
@@ -108,7 +117,7 @@ msgstr ""
 "这是一封自动发送的邮件；如果您没有要求重置密码而收到此信，不需要进行任何操"
 "作。"
 
-#: server/templates/email/reset.html:6 server/templates/email/verify.html:6
+#: templates/reset.html:6 templates/unlock.html:5 templates/verify.html:6
 msgid ""
 "For more information, please visit <a href='https://support.mozilla."
 "org'>Mozilla Support</a>"
@@ -116,37 +125,53 @@ msgstr ""
 "要了解更多信息，请访问<a href='https://support.mozilla.org'>Mozilla 技术支持"
 "</a>"
 
-#: server/templates/email/reset.txt:3
+#: templates/reset.txt:3
 msgid "Reset password:"
 msgstr "重置密码："
 
-#: server/templates/email/reset.txt:5 server/templates/email/verify.txt:5
+#: templates/reset.txt:5 templates/unlock.txt:4 templates/verify.txt:5
 msgid "For more information, please visit https://support.mozilla.org"
 msgstr "要了解更多信息，请访问 https://support.mozilla.org"
 
-#: server/templates/email/verify.html:2 server/templates/email/verify.txt:1
-msgid "Congratulations!"
-msgstr "恭喜！"
+#: templates/unlock.html:2 templates/unlock.txt:1
+msgid ""
+"For security reasons your Firefox Account was put on lockdown. To perform "
+"account-level activities, please click the link to re-verify your account "
+"now."
+msgstr ""
 
-#: server/templates/email/verify.html:3 server/templates/email/verify.txt:2
+#: templates/unlock.html:3
+msgid "Verify account"
+msgstr ""
+
+#: templates/unlock.txt:2
+msgid "Verify account:"
+msgstr ""
+
+#: templates/verify.html:2 templates/verify.txt:1
+msgid "Almost there"
+msgstr ""
+
+#: templates/verify.html:3 templates/verify.txt:2
 msgid "%(email)s, you're one click away from verifying your Firefox Account."
 msgstr "%(email)s, 只要再用几秒钟的时间就可以验证您的 Firefox 账号了。"
 
-#: server/templates/email/verify.html:4
+#: templates/verify.html:4
 msgid "Verify"
 msgstr "验证"
 
-#: server/templates/email/verify.txt:3
+#: templates/verify.txt:3
 msgid "Verify:"
 msgstr "验证："
 
-#: server/lib/templates.js:63
-msgid "Verify your account"
-msgstr "验证您的账号"
+#~ msgid "Congratulations!"
+#~ msgstr "恭喜！"
 
-#: server/lib/templates.js:68
-msgid "Reset your password"
-msgstr "重置密码"
+#~ msgid "Verify your account"
+#~ msgstr "验证您的账号"
+
+#~ msgid "Reset your password"
+#~ msgstr "重置密码"
 
 #~ msgid "System unavailable, try again soon"
 #~ msgstr "系统不可用，请稍后再试"

--- a/locale/zh_TW/LC_MESSAGES/server.po
+++ b/locale/zh_TW/LC_MESSAGES/server.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-02-20 19:15+0000\n"
+"POT-Creation-Date: 2015-02-25 18:58+0000\n"
 "PO-Revision-Date: 2014-10-11 19:55+0000\n"
 "Last-Translator: Peter <petercpg@mail.moztw.org>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -19,7 +19,8 @@ msgstr ""
 #: server/templates/pages/src/503.html:1
 #: server/templates/pages/src/index.html:1
 #: server/templates/pages/src/privacy.html:1
-#: server/templates/pages/src/terms.html:1
+#: server/templates/pages/src/terms.html:1 templates/reset.html:1
+#: templates/unlock.html:1 templates/verify.html:1
 msgid "Firefox Accounts"
 msgstr "Firefox 帳號"
 
@@ -97,47 +98,76 @@ msgstr "Firefox 雲端服務"
 msgid "Terms of Service"
 msgstr "服務條款"
 
-#~ msgid "Are you sure?"
-#~ msgstr "您確定嗎？"
+#: templates/reset.html:2 templates/reset.txt:1
+msgid "Are you sure?"
+msgstr "您確定嗎？"
 
-#~ msgid "Please confirm that you'd like to reset the password for %(email)s."
-#~ msgstr "請確認您要重設帳號 %(email)s 的密碼。"
+#: templates/reset.html:3 templates/reset.txt:2
+msgid "Please confirm that you'd like to reset the password for %(email)s."
+msgstr "請確認您要重設帳號 %(email)s 的密碼。"
 
-#~ msgid "Reset password"
-#~ msgstr "重設密碼"
+#: templates/reset.html:4
+msgid "Reset password"
+msgstr "重設密碼"
 
-#~ msgid ""
-#~ "This is an automated email; if you received it in error, no action is "
-#~ "required."
-#~ msgstr ""
-#~ "這是電腦自動發送的郵件，若您並未要求重設密碼而突然收到這封信，不需要做任何"
-#~ "事。"
+#: templates/reset.html:5 templates/reset.txt:4 templates/unlock.html:4
+#: templates/unlock.txt:3 templates/verify.html:5 templates/verify.txt:4
+msgid ""
+"This is an automated email; if you received it in error, no action is "
+"required."
+msgstr ""
+"這是電腦自動發送的郵件，若您並未要求重設密碼而突然收到這封信，不需要做任何"
+"事。"
 
-#~ msgid ""
-#~ "For more information, please visit <a href='https://support.mozilla."
-#~ "org'>Mozilla Support</a>"
-#~ msgstr ""
-#~ "若需更多資訊，請參考 <a href='https://support.mozilla.org'>Mozilla 技術支"
-#~ "援站</a>"
+#: templates/reset.html:6 templates/unlock.html:5 templates/verify.html:6
+msgid ""
+"For more information, please visit <a href='https://support.mozilla."
+"org'>Mozilla Support</a>"
+msgstr ""
+"若需更多資訊，請參考 <a href='https://support.mozilla.org'>Mozilla 技術支援站"
+"</a>"
 
-#~ msgid "Reset password:"
-#~ msgstr "重設密碼:"
+#: templates/reset.txt:3
+msgid "Reset password:"
+msgstr "重設密碼:"
 
-#~ msgid "For more information, please visit https://support.mozilla.org"
-#~ msgstr "若需更多資訊，請參考 https://support.mozilla.org"
+#: templates/reset.txt:5 templates/unlock.txt:4 templates/verify.txt:5
+msgid "For more information, please visit https://support.mozilla.org"
+msgstr "若需更多資訊，請參考 https://support.mozilla.org"
+
+#: templates/unlock.html:2 templates/unlock.txt:1
+msgid ""
+"For security reasons your Firefox Account was put on lockdown. To perform "
+"account-level activities, please click the link to re-verify your account "
+"now."
+msgstr ""
+
+#: templates/unlock.html:3
+msgid "Verify account"
+msgstr ""
+
+#: templates/unlock.txt:2
+msgid "Verify account:"
+msgstr ""
+
+#: templates/verify.html:2 templates/verify.txt:1
+msgid "Almost there"
+msgstr ""
+
+#: templates/verify.html:3 templates/verify.txt:2
+msgid "%(email)s, you're one click away from verifying your Firefox Account."
+msgstr "%(email)s，您只需要再花幾秒鐘就能將您的 Firefox 帳號驗證完成。"
+
+#: templates/verify.html:4
+msgid "Verify"
+msgstr "驗證"
+
+#: templates/verify.txt:3
+msgid "Verify:"
+msgstr "驗證:"
 
 #~ msgid "Congratulations!"
 #~ msgstr "恭喜！"
-
-#~ msgid ""
-#~ "%(email)s, you're one click away from verifying your Firefox Account."
-#~ msgstr "%(email)s，您只需要再花幾秒鐘就能將您的 Firefox 帳號驗證完成。"
-
-#~ msgid "Verify"
-#~ msgstr "驗證"
-
-#~ msgid "Verify:"
-#~ msgstr "驗證:"
 
 #~ msgid "Verify your account"
 #~ msgstr "驗證您的帳號"

--- a/locale/zu/LC_MESSAGES/server.po
+++ b/locale/zu/LC_MESSAGES/server.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-02-20 19:15+0000\n"
+"POT-Creation-Date: 2015-02-25 18:58+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "Language: \n"
@@ -15,7 +15,8 @@ msgstr ""
 #: server/templates/pages/src/503.html:1
 #: server/templates/pages/src/index.html:1
 #: server/templates/pages/src/privacy.html:1
-#: server/templates/pages/src/terms.html:1
+#: server/templates/pages/src/terms.html:1 templates/reset.html:1
+#: templates/unlock.html:1 templates/verify.html:1
 msgid "Firefox Accounts"
 msgstr ""
 
@@ -87,4 +88,68 @@ msgstr ""
 #: server/templates/pages/src/terms.html:2
 #: server/templates/pages/src/terms.html:5
 msgid "Terms of Service"
+msgstr ""
+
+#: templates/reset.html:2 templates/reset.txt:1
+msgid "Are you sure?"
+msgstr ""
+
+#: templates/reset.html:3 templates/reset.txt:2
+msgid "Please confirm that you'd like to reset the password for %(email)s."
+msgstr ""
+
+#: templates/reset.html:4
+msgid "Reset password"
+msgstr ""
+
+#: templates/reset.html:5 templates/reset.txt:4 templates/unlock.html:4
+#: templates/unlock.txt:3 templates/verify.html:5 templates/verify.txt:4
+msgid ""
+"This is an automated email; if you received it in error, no action is "
+"required."
+msgstr ""
+
+#: templates/reset.html:6 templates/unlock.html:5 templates/verify.html:6
+msgid ""
+"For more information, please visit <a href='https://support.mozilla."
+"org'>Mozilla Support</a>"
+msgstr ""
+
+#: templates/reset.txt:3
+msgid "Reset password:"
+msgstr ""
+
+#: templates/reset.txt:5 templates/unlock.txt:4 templates/verify.txt:5
+msgid "For more information, please visit https://support.mozilla.org"
+msgstr ""
+
+#: templates/unlock.html:2 templates/unlock.txt:1
+msgid ""
+"For security reasons your Firefox Account was put on lockdown. To perform "
+"account-level activities, please click the link to re-verify your account "
+"now."
+msgstr ""
+
+#: templates/unlock.html:3
+msgid "Verify account"
+msgstr ""
+
+#: templates/unlock.txt:2
+msgid "Verify account:"
+msgstr ""
+
+#: templates/verify.html:2 templates/verify.txt:1
+msgid "Almost there"
+msgstr ""
+
+#: templates/verify.html:3 templates/verify.txt:2
+msgid "%(email)s, you're one click away from verifying your Firefox Account."
+msgstr ""
+
+#: templates/verify.html:4
+msgid "Verify"
+msgstr ""
+
+#: templates/verify.txt:3
+msgid "Verify:"
 msgstr ""


### PR DESCRIPTION
@shane-tomlinson @mathjazz I've added the translations back and updated the template.