### PR TITLE
Remove unexpected `em` tags in the Italian translation.

### DIFF
--- a/locale/it/LC_MESSAGES/client.po
+++ b/locale/it/LC_MESSAGES/client.po
@@ -742,7 +742,7 @@ msgstr "Scarica Firefox per Android."
 
 #: app/scripts/templates/marketing_snippet_ios.mustache:10
 msgid "Download Firefox for mobile devices."
-msgstr "Scarica Firefox per dispositivi <em>mobile</em>."
+msgstr "Scarica Firefox per dispositivi mobile."
 
 #: app/scripts/templates/permissions.mustache:1
 #: app/scripts/templates/settings/gravatar_permissions.mustache:1


### PR DESCRIPTION
`Scarica Firefox per dispositivi <em>mobile</em>.` =>
`Scarica Firefox per dispositivi mobile.`

@mathjazz - could you review this? I found the extra tag while working on a linting tool (see https://github.com/mozilla/grunt-l10n-lint)