### PR TITLE
Updated Polish (pl) localization of Firefox Accounts for train 56

### DIFF
--- a/locale/pl/LC_MESSAGES/client.po
+++ b/locale/pl/LC_MESSAGES/client.po
@@ -3,7 +3,7 @@ msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2016-02-05 22:55+0000\n"
-"PO-Revision-Date: 2015-12-22 17:10+0100\n"
+"PO-Revision-Date: 2016-02-09 13:12+0100\n"
 "Last-Translator: Piotr Drąg <piotrdrag@gmail.com>\n"
 "Language-Team: Polish <community-poland@mozilla.org>\n"
 "Language: pl\n"
@@ -443,6 +443,8 @@ msgstr ""
 msgid ""
 "Have an account with a different email? <a href=\"%(signinUri)s\">Sign in</a>"
 msgstr ""
+"Masz już konto z innym adresem e-mail? <a href=\"%(signinUri)s\">Zaloguj "
+"się</a>"
 
 #: app/scripts/templates/cannot_create_account.mustache:1
 msgid "Cannot create account"
@@ -655,7 +657,7 @@ msgstr "Zaloguj"
 
 #: app/scripts/templates/cookies_disabled.mustache:1
 msgid "Cookies and local storage are required."
-msgstr ""
+msgstr "Wymagana jest obsługa ciasteczek i lokalnego przechowywania danych."
 
 #: app/scripts/templates/cookies_disabled.mustache:2
 msgid ""
@@ -663,6 +665,9 @@ msgid ""
 "Accounts. Doing so will enable functionality such as remembering you between "
 "sessions."
 msgstr ""
+"Proszę włączyć obsługę ciasteczek i lokalnego przechowywania danych w "
+"przeglądarce, aby uzyskać dostęp do konta Firefoksa. Dzięki temu włączona "
+"zostanie funkcja zapamiętywania użytkownika między sesjami."
 
 #: app/scripts/templates/cookies_disabled.mustache:3
 msgid "Learn more"
@@ -1035,21 +1040,3 @@ msgstr "Użyj OpenID"
 #: app/scripts/templates/openid/start.mustache:4
 msgid "Use Firefox Account"
 msgstr "Użyj konta Firefoksa"
-
-#~ msgid "Desktop Add-ons"
-#~ msgstr "Dodatki dla komputerów"
-
-#~ msgid "Desktop Preferences"
-#~ msgstr "Ustawienia wersji na komputery"
-
-#~ msgid "Cookies required"
-#~ msgstr "Wymagana jest obsługa ciasteczek"
-
-#~ msgid ""
-#~ "Please enable cookies in your browser which are required by Firefox "
-#~ "Accounts. Cookies are small pieces of data stored in your browser that "
-#~ "provide functionality such as remembering you between sessions."
-#~ msgstr ""
-#~ "Proszę włączyć obsługę ciasteczek w przeglądarce. Ciasteczka to małe "
-#~ "porcje danych przechowywane przez przeglądarkę, aby zachowywać dane "
-#~ "logowania między sesjami."


### PR DESCRIPTION
I'm leaving untranslatable strings in client.po out for now (issue #104).

Also, I wasn't sure what to do about the two new strings in server.po. Are you sure they should be marked for translation?

@splewako 