### PR TITLE
fix(git): Only ignore client.pot and server.pot in templates/LC_MESSAGES

### DIFF
--- a/locale/templates/LC_MESSAGES/.gitignore
+++ b/locale/templates/LC_MESSAGES/.gitignore
@@ -1,4 +1,5 @@
 ### Ignore files generated in LC_MESSAGES directory
 ### See https://github.com/mozilla/fxa-content-server/issues/3258 for details
-*
+client.pot
+server.pot
 !.gitignore


### PR DESCRIPTION
fixes #158

@vladikoff - r?