### PR TITLE
Use Mozilla plural forms in AR locale

### DIFF
--- a/locale/ar/LC_MESSAGES/client.po
+++ b/locale/ar/LC_MESSAGES/client.po
@@ -11,7 +11,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=6; plural=(n==0 ? 0 : n==1 ? 1 : n==2 ? 2 : n%100>=3 && n%100<=10 ? 3 : n%100>=11 ? 4 : 5);\n"
+"Plural-Forms: nplurals=6; plural=n==0 ? 5 : n==1 ? 0 : n==2 ? 1 : n%100>=3 && n%100<=10 ? 2 : n%100>=11 ? 3 : 4; \n"
 "X-Generator: Pontoon\n"
 
 #: .es5/views/confirm_reset_password.js:195

--- a/locale/ar/LC_MESSAGES/server.po
+++ b/locale/ar/LC_MESSAGES/server.po
@@ -11,7 +11,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=6; plural=(n==0 ? 0 : n==1 ? 1 : n==2 ? 2 : n%100>=3 && n%100<=10 ? 3 : n%100>=11 ? 4 : 5);\n"
+"Plural-Forms: nplurals=6; plural=n==0 ? 5 : n==1 ? 0 : n==2 ? 1 : n%100>=3 && n%100<=10 ? 2 : n%100>=11 ? 3 : 4; \n"
 "X-Generator: Pontoon\n"
 
 #: lib/senders/templates/_pending.txt:1


### PR DESCRIPTION
Fixes https://github.com/mozilla/fxa-auth-server/issues/2714

@flodolo @mathjazz Any ideas here why the current Plural form would be causing problems?

If I change it to this one or switch it with a Russian one, then it fixes https://github.com/mozilla/fxa-auth-server/issues/2714 and Arabic translations start working again. Have you seen that before?



Ref: https://www.arabeyes.org/Plural_Forms

cc @philbooth 
