### PR TITLE
fix(l10n): fix french translation for post change primary email

### DIFF
--- a/locale/fr/LC_MESSAGES/server.po
+++ b/locale/fr/LC_MESSAGES/server.po
@@ -295,7 +295,7 @@ msgid ""
 "You have successfully changed your primary email to %(email)s. This address is now your username for signing in to your Firefox Account, as well as receiving security notifications and sign-in "
 "confirmations."
 msgstr ""
-"Votre adresse électronique principale est désormais %(secondaryEmail)s. Cette adresse est à présent votre nom d’utilisateur pour vous connecter à votre compte Firefox et elle recevra les "
+"Votre adresse électronique principale est désormais %(email)s. Cette adresse est à présent votre nom d’utilisateur pour vous connecter à votre compte Firefox et elle recevra les "
 "notifications de sécurité et les confirmations de connexion."
 
 #: lib/senders/templates/post_consume_recovery_code.html:2 lib/senders/email.js:1213


### PR DESCRIPTION
@shane-tomlinson @vladikoff Never fixed an l10n issue before so not sure if this is the right process?

Fixes https://bugzilla.mozilla.org/show_bug.cgi?id=1542704