### PR TITLE
retrieve ftl files in fxa-auth-server

### DIFF
--- a/scripts/extract-and-pull-request.sh
+++ b/scripts/extract-and-pull-request.sh
@@ -7,6 +7,7 @@ mkdir workspace
 (cd workspace && git clone --depth 1 https://github.com/mozilla/fxa)
 (cd workspace/fxa && yarn workspaces focus fxa-content-server fxa-auth-server fxa-payments-server fxa-settings)
 (cd workspace/fxa && yarn workspace fxa-settings build)
+(cd workspace/fxa && yarn workspace fxa-auth-server grunt merge-ftl)
 
 # random release number, avoids collision with old trains or branches
 r=$(( $RANDOM + $RANDOM + 1000 ))

--- a/scripts/extract_strings.sh
+++ b/scripts/extract_strings.sh
@@ -93,6 +93,7 @@ msgfilter -i $L10N_DIR/locale/sr/LC_MESSAGES/server.po -o $L10N_DIR/locale/sr_La
 
 cp $PAYMENTS_DIR/public/locales/en-US/*.ftl $L10N_DIR/locale/templates
 cp $SETTINGS_DIR/public/locales/en-US/*.ftl $L10N_DIR/locale/templates
+cp $MAILER_DIR/public/locales/en-US/*.ftl $L10N_DIR/locale/templates
 
 cd $L10N_DIR
 git checkout -b merge-train-$TRAIN_NUMBER-strings


### PR DESCRIPTION
We're transitioning the `fxa-auth-server` to an updated email system, part of which includes using Fluent.

This PR (hopefully) updates the scripts to look for FTL files in the auth-server.