### PR TITLE
upgrade deprecated gh cli version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ jobs:
 
             openssl aes-256-cbc -md md5 -d -in secret-env-cipher -k $KEY >> ~/.circlerc
             sudo apt-get update; sudo apt-get install gettext graphicsmagick
-            sudo npm install -g grunt-cli gh@1.12.14
+            sudo npm install -g grunt-cli gh@2.8.9
             source ~/.circlerc
             GITHUB_TOKEN=$GITHUB_TOKEN GITHUB_USER=$GITHUB_USER node scripts/ci-creds.js
             mkdir -p ~/.config/configstore/


### PR DESCRIPTION
The build CI job is [failing](https://app.circleci.com/pipelines/github/mozilla/fxa-content-server-l10n/3768/workflows/447187b5-cf18-43f3-96c9-7439842f90ca/jobs/10016) right now:

> [Error: {"message":"Must specify access token via Authorization header. https://developer.github.com/changes/2020-02-10-deprecating-auth-through-query-param","documentation_url":"https://docs.github.com/v3/#oauth2-token-sent-in-a-header"}] {
  code: 400
}

Problem is, this script utilizes the deprecated [gh](https://www.npmjs.com/package/gh) CLI. However, it was on version 1.12.14, and the most recent (and last) version is 2.8.9, so my hope is that they addressed this issue in that time.

If this fails I've started working on a new version of the script that uses the official [GH CLI](https://cli.github.com/), but before I spend more time I want to see if we can fix the issue for free.