### PR TITLE
specify use_editor:false for gh cli

### DIFF
--- a/scripts/ci-creds.js
+++ b/scripts/ci-creds.js
@@ -2,5 +2,6 @@ const fs = require('fs');
 
 fs.writeFileSync('.gh.json', JSON.stringify({
   github_token: process.env.GITHUB_TOKEN,
-  github_user: process.env.GITHUB_USER
+  github_user: process.env.GITHUB_USER,
+  use_editor: false,
 }));


### PR DESCRIPTION
Hopefully fixes the most recent build failure, according to [this](https://github.com/node-gh/gh/issues/755)