### PR TITLE
Change location of default locale in auth-server from en-US to en

### DIFF
--- a/scripts/extract_strings.sh
+++ b/scripts/extract_strings.sh
@@ -93,7 +93,7 @@ msgfilter -i $L10N_DIR/locale/sr/LC_MESSAGES/server.po -o $L10N_DIR/locale/sr_La
 
 cp $PAYMENTS_DIR/public/locales/en-US/*.ftl $L10N_DIR/locale/templates
 cp $SETTINGS_DIR/public/locales/en-US/*.ftl $L10N_DIR/locale/templates
-cp $MAILER_DIR/public/locales/en-US/*.ftl $L10N_DIR/locale/templates
+cp $MAILER_DIR/public/locales/en/*.ftl $L10N_DIR/locale/templates
 
 cd $L10N_DIR
 git checkout -b merge-train-$TRAIN_NUMBER-strings


### PR DESCRIPTION
Think this should fix the script. We changed the default locale from `en-US` to `en`, so it was looking in the wrong spot.