### PR TITLE
fix: capital 'E' on Secondary email header

### DIFF
--- a/locale/en_GB/settings.ftl
+++ b/locale/en_GB/settings.ftl
@@ -472,7 +472,7 @@ rk-remove-error = Your account recovery key could not be removed.
 ## Secondary email sub-section on main Settings page
 
 se-heading = Secondary email
-    .header = Secondary Email
+    .header = Secondary email
 se-cannot-refresh-email = Sorry, there was a problem refreshing that email.
 se-cannot-resend-code = Sorry, there was a problem re-sending the verification code.
 # This string is used in a notification message near the top of the page.


### PR DESCRIPTION
Because:
* capitalization of E is inconsistent with our other headers
This pull request:
* changes the uppercase E in Secondary Email to lowercase e
Closes: 9138