### PR TITLE
Enable auth-server extract strings/extract and PR commands

### DIFF
--- a/scripts/extract-and-pull-request.sh
+++ b/scripts/extract-and-pull-request.sh
@@ -7,9 +7,7 @@ mkdir workspace
 (cd workspace && git clone --depth 1 https://github.com/mozilla/fxa)
 (cd workspace/fxa && yarn workspaces focus fxa-content-server fxa-auth-server fxa-payments-server fxa-settings)
 (cd workspace/fxa && yarn workspace fxa-settings build)
-
-# We should re-enable once auth-server is ready to support ftl
-# (cd workspace/fxa && yarn workspace fxa-auth-server grunt merge-ftl)
+(cd workspace/fxa && yarn workspace fxa-auth-server grunt merge-ftl)
 
 # random release number, avoids collision with old trains or branches
 r=$(( $RANDOM + $RANDOM + 1000 ))

--- a/scripts/extract_strings.sh
+++ b/scripts/extract_strings.sh
@@ -93,9 +93,7 @@ msgfilter -i $L10N_DIR/locale/sr/LC_MESSAGES/server.po -o $L10N_DIR/locale/sr_La
 
 cp $PAYMENTS_DIR/public/locales/en-US/*.ftl $L10N_DIR/locale/templates
 cp $SETTINGS_DIR/public/locales/en-US/*.ftl $L10N_DIR/locale/templates
-
-# We should re-enable once auth-server is ready to support ftl
-# cp $MAILER_DIR/public/locales/en/*.ftl $L10N_DIR/locale/templates
+cp $MAILER_DIR/public/locales/en/*.ftl $L10N_DIR/locale/templates
 
 cd $L10N_DIR
 git checkout -b merge-train-$TRAIN_NUMBER-strings


### PR DESCRIPTION
Now that auth.ftl has been merged, we can re-enable the extraction from the auth server.