### PR TITLE
Remove commented out lines in extract_strings.sh

### DIFF
--- a/scripts/extract_strings.sh
+++ b/scripts/extract_strings.sh
@@ -61,10 +61,6 @@ case $param in
 esac
 done
 
-#if [[ ! $1 =~ ^[0-9]+$ ]]; then
-    #usage;
-#fi
-
 TRAIN_NUMBER=$1
 
 printf "Checking $MAILER_DIR.. "
@@ -80,9 +76,8 @@ check_folder $L10N_DIR
 
 set -x
 
-#(cd $MAILER_DIR && rm -f server.pot && npx grunt l10n-extract)
-#cp $MAILER_DIR/server.pot $CONTENT_DIR/locale/templates/LC_MESSAGES/
 
+# Gettext extraction
 (cd $CONTENT_DIR && npx grunt l10n-extract)
 cp -r $CONTENT_DIR/locale/templates/* $L10N_DIR/locale/templates
 
@@ -91,6 +86,7 @@ cp -r $CONTENT_DIR/locale/templates/* $L10N_DIR/locale/templates
 msgfilter -i $L10N_DIR/locale/sr/LC_MESSAGES/client.po -o $L10N_DIR/locale/sr_Latn/LC_MESSAGES/client.po recode-sr-latin
 msgfilter -i $L10N_DIR/locale/sr/LC_MESSAGES/server.po -o $L10N_DIR/locale/sr_Latn/LC_MESSAGES/server.po recode-sr-latin
 
+# Fluent extraction
 cp $PAYMENTS_DIR/public/locales/en-US/*.ftl $L10N_DIR/locale/templates
 cp $SETTINGS_DIR/public/locales/en-US/*.ftl $L10N_DIR/locale/templates
 cp $MAILER_DIR/public/locales/en/*.ftl $L10N_DIR/locale/templates


### PR DESCRIPTION
@clouserw commented out these lines yesterday:

```
#(cd $MAILER_DIR && rm -f server.pot && npx grunt l10n-extract)
#cp $MAILER_DIR/server.pot $CONTENT_DIR/locale/templates/LC_MESSAGES/
```

This was failing because after mozilla/fxa/pull/12390, the auth-server no longer has an `l10n-extract` grunttask. We can indeed remove these from the script.

Since the 2nd line gave me pause as it references the `fxa-content-sever`, I tested that the extraction for the content server, which still has a few translations in `server.po`, still works as expected locally by deleting the `locale` directory, changing a string in a content-server `server/` directory, running `l10n-extract` in content-server, and seeing the new string in `locale/templates/server.po`. In this script, after that grunttask is ran, we copy the directory over with these commands.

```
(cd $CONTENT_DIR && npx grunt l10n-extract)
cp -r $CONTENT_DIR/locale/templates/* $L10N_DIR/locale/templates
```
