### PR TITLE
Include en and en-US FTL files in locale/

### DIFF
--- a/scripts/extract_strings.sh
+++ b/scripts/extract_strings.sh
@@ -102,11 +102,6 @@ else
     ./scripts/merge_po.sh ./locale
 fi
 
-# Fluent extraction
-cp $PAYMENTS_DIR/public/locales/en-US/*.ftl $L10N_DIR/locale/templates
-cp $SETTINGS_DIR/public/locales/en-US/*.ftl $L10N_DIR/locale/templates
-cp $MAILER_DIR/public/locales/en/*.ftl $L10N_DIR/locale/templates
-
 # Some locales must be copied over to a different locale code
 # See details in https://github.com/mozilla/fxa-content-server-l10n/pull/79#issuecomment-149281761
 cp -r $L10N_DIR/locale/sv_SE/* $L10N_DIR/locale/sv
@@ -124,5 +119,16 @@ sed -i'' -e 's/Language: pt_PT/Language: pt/g' "$L10N_DIR/locale/pt/LC_MESSAGES/
 cp -r $L10N_DIR/locale/fy_NL/* $L10N_DIR/locale/fy
 sed -i'' -e 's/Language: fy_NL/Language: fy/g' "$L10N_DIR/locale/fy/LC_MESSAGES/client.po"
 sed -i'' -e 's/Language: fy_NL/Language: fy/g' "$L10N_DIR/locale/fy/LC_MESSAGES/server.po"
+
+# Fluent extraction
+cp $PAYMENTS_DIR/public/locales/en-US/*.ftl $L10N_DIR/locale/templates
+cp $SETTINGS_DIR/public/locales/en-US/*.ftl $L10N_DIR/locale/templates
+cp $MAILER_DIR/public/locales/en/*.ftl $L10N_DIR/locale/templates
+
+# Pontoon will read from the "templates" directory but we must copy the FTL files
+# into "en" to ensure users with English will always see good fallback text.
+# We can remove the "templates" directory once we are off of gettext entirely -
+# then, Pontoon will read from the "en" directory.
+cp $L10N_DIR/locale/templates/*.ftl $L10N_DIR/locale/en
 
 set +x


### PR DESCRIPTION
There's been some discussion lately on whether or not we _want_ to rely purely on fallback text for en/en-US users, as we have been since setting Fluent up in FxA as far as I know. We had a recent bug show us that English/US users were actually very likely seeing `en-GB` locales (see [more info here](https://github.com/mozilla/fxa/pull/12861#issuecomment-1125440236)), and since changing the Fluent strategy to be more precise in its matching, our fallback text is showing as expected. However, we keep uncovering instances where we haven't supplied fallback text, which has created several fairly severe (from a UI point of view) bugs, the newest few coming up today.

While discussions on how we handle fallback text are still ongoing and at the time of writing we want to always supply fallback text, the team seems to agree on at least on including our English FTL files in the `locale` directory for consistency, and I believe we should go ahead and do this now to prevent any further "fallback text missing" surprises when we push to production.