### PR TITLE
Linter: check for string changes without new IDs

### DIFF
--- a/.github/requirements.txt
+++ b/.github/requirements.txt
@@ -1,1 +1,2 @@
 moz-fluent-linter==0.3.*
+compare-locales==8.2.*

--- a/.github/scripts/detect_unchanged_ids.py
+++ b/.github/scripts/detect_unchanged_ids.py
@@ -1,0 +1,113 @@
+import os
+import sys
+import argparse
+
+try:
+    from compare_locales import parser
+except ImportError as e:
+    print("FATAL: make sure that dependencies are installed")
+    print(e)
+    sys.exit(1)
+
+
+def get_file_list(path):
+    """Get the list of supported files."""
+    file_list = []
+    for root, dirs, files in os.walk(path, followlinks=True):
+        for file in files:
+            if file.endswith(".ftl"):
+                file_list.append(os.path.join(root, file))
+    file_list.sort()
+
+    return file_list
+
+
+def generate_dict(file_name):
+    file_parser = parser.getParser(".ftl")
+    file_parser.readFile(file_name)
+    try:
+        entities = file_parser.parse()
+        entity_dict = {}
+        for entity in entities:
+            # Ignore Junk
+            if isinstance(entity, parser.Junk):
+                continue
+            string_id = f"{entity}"
+            if entity.raw_val is not None:
+                entity_dict[string_id] = entity.raw_val
+            # Store attributes
+            for attribute in entity.attributes:
+                attr_string_id = f"{entity}.{attribute}"
+                entity_dict[attr_string_id] = attribute.raw_val
+        return entity_dict
+    except Exception as e:
+        print(f"Error parsing file: {file_name}")
+        print(e)
+
+
+def find_changed_ids(file_old, file_new):
+    dict_old = generate_dict(file_old)
+    dict_new = generate_dict(file_new)
+    return {
+        key: {"previous": dict_old[key], "new": dict_new[key]}
+        for key in dict_old.keys()
+        if key in dict_new and dict_old[key] != dict_new[key]
+    }
+
+
+def main():
+    arg_parser = argparse.ArgumentParser()
+    arg_parser.add_argument(
+        "--base_dir",
+        required=True,
+        help="Folder with the previous version of files (copied from base repository)",
+    )
+    arg_parser.add_argument(
+        "--head_dir",
+        required=True,
+        help="Folder with the new version of files (copied from head repository)",
+    )
+    args = arg_parser.parse_args()
+
+    errors = {}
+
+    script_path = os.path.dirname(__file__)
+    root_path = os.path.abspath(os.path.join(script_path, os.pardir, os.pardir))
+
+    path_old = os.path.join(root_path, args.base_dir)
+    path_new = os.path.join(root_path, args.head_dir)
+
+    files_old = get_file_list(path_old)
+    files_new = get_file_list(path_new)
+
+    for file_old, file_new in zip(files_old, files_new):
+        filename = os.path.relpath(file_old, path_old)
+        errors[filename] = find_changed_ids(file_old, file_new)
+
+    if errors:
+        files = list(errors.keys())
+        files.sort()
+
+        output = []
+        total_errors = 0
+        for file in files:
+            output.append(f"\nFile: {file}")
+
+            ids = list(errors[file].keys())
+            ids.sort()
+            for id in ids:
+                output.append(
+                    f"\nID: {id}"
+                    f"\nPrevious: {errors[file][id]['previous']}"
+                    f"\nNew: {errors[file][id]['new']}"
+                )
+                total_errors += 1
+        output.append(f"\nTotal errors: {total_errors}")
+
+        sys.exit("\n".join(output))
+    else:
+        print("No unchanged IDs found.")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/detect_unchanged_ids.py
+++ b/.github/scripts/detect_unchanged_ids.py
@@ -10,11 +10,11 @@ except ImportError as e:
     sys.exit(1)
 
 
-def get_file_list(path, reference_locale="locale/en"):
+def get_file_list(path, reference_locale_path):
     """Get the list of supported files in a reference locale."""
     file_list = []
-    reference_locale_path = os.path.join(path, reference_locale)
-    for root, dirs, files in os.walk(reference_locale_path, followlinks=True):
+    target_path = os.path.join(path, reference_locale_path)
+    for root, dirs, files in os.walk(target_path, followlinks=True):
         for file in files:
             if file.endswith(".ftl"):
                 file_list.append(os.path.join(root, file))
@@ -68,6 +68,11 @@ def main():
         required=True,
         help="Folder with the new version of files (copied from head repository)",
     )
+    arg_parser.add_argument(
+        "--locale_dir",
+        required=True,
+        help='Path to reference locale (e.g. "locale/en")',
+    )
     args = arg_parser.parse_args()
 
     errors = {}
@@ -77,9 +82,10 @@ def main():
 
     path_old = os.path.join(root_path, args.base_dir)
     path_new = os.path.join(root_path, args.head_dir)
+    path_locale = args.locale_dir
 
-    files_old = get_file_list(path_old)
-    files_new = get_file_list(path_new)
+    files_old = get_file_list(path_old, path_locale)
+    files_new = get_file_list(path_new, path_locale)
 
     for file_old, file_new in zip(files_old, files_new):
         filename = os.path.relpath(file_old, path_old)

--- a/.github/scripts/detect_unchanged_ids.py
+++ b/.github/scripts/detect_unchanged_ids.py
@@ -10,10 +10,11 @@ except ImportError as e:
     sys.exit(1)
 
 
-def get_file_list(path):
-    """Get the list of supported files."""
+def get_file_list(path, reference_locale="locale/en"):
+    """Get the list of supported files in a reference locale."""
     file_list = []
-    for root, dirs, files in os.walk(path, followlinks=True):
+    reference_locale_path = os.path.join(path, reference_locale)
+    for root, dirs, files in os.walk(reference_locale_path, followlinks=True):
         for file in files:
             if file.endswith(".ftl"):
                 file_list.append(os.path.join(root, file))
@@ -82,7 +83,9 @@ def main():
 
     for file_old, file_new in zip(files_old, files_new):
         filename = os.path.relpath(file_old, path_old)
-        errors[filename] = find_changed_ids(file_old, file_new)
+        changes = find_changed_ids(file_old, file_new)
+        if changes:
+            errors[filename] = changes
 
     if errors:
         files = list(errors.keys())

--- a/.github/workflows/reference_linter.yaml
+++ b/.github/workflows/reference_linter.yaml
@@ -19,6 +19,8 @@ jobs:
     steps:
       - name: Clone repository
         uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
       - name: Set up Python 3
         uses: actions/setup-python@v4
         with:
@@ -30,3 +32,13 @@ jobs:
       - name: Lint reference
         run: |
           moz-fluent-lint ./locale/en --config .github/linter_config.yml
+      - name: Check for unchanged IDs
+        run: |
+            diff=$( git diff --name-only ${{ github.event.pull_request.base.sha }} $GITHUB_SHA )
+            for file in $diff; do
+              mkdir -p "old/${file%/*}/" && mkdir -p "new/${file%/*}/"
+              git show ${{ github.event.pull_request.base.sha }}:$file > temp_base/$file
+              git show $GITHUB_SHA:$file > temp_head/$file
+            done
+            python .github/scripts/detect_unchanged_ids.py --base_dir temp_base --head_dir temp_head
+        if: github.event_name == 'pull_request'

--- a/.github/workflows/reference_linter.yaml
+++ b/.github/workflows/reference_linter.yaml
@@ -36,9 +36,9 @@ jobs:
         run: |
             diff=$( git diff --name-only ${{ github.event.pull_request.base.sha }} $GITHUB_SHA )
             for file in $diff; do
-              mkdir -p "old/${file%/*}/" && mkdir -p "new/${file%/*}/"
+              mkdir -p "temp_base/${file%/*}/" && mkdir -p "temp_head/${file%/*}/"
               git show ${{ github.event.pull_request.base.sha }}:$file > temp_base/$file
               git show $GITHUB_SHA:$file > temp_head/$file
             done
-            python .github/scripts/detect_unchanged_ids.py --base_dir temp_base --head_dir temp_head
+            python .github/scripts/detect_unchanged_ids.py --base_dir temp_base --head_dir temp_head --locale_dir locale/en
         if: github.event_name == 'pull_request'


### PR DESCRIPTION
Revised PR based on feedback from #615
- Now uses compare-locales to parse
- Bash script no longer changes filenames, instead moves files to old/ and new/ folders
- Integrated into reference locale linter action