### PR TITLE
Export: Remove obsolete strings from localized .po files

### DIFF
--- a/scripts/merge_po.sh
+++ b/scripts/merge_po.sh
@@ -19,7 +19,9 @@ for lang in `find $1 -type f -name "*.po" -not -path '*/db_LB/*'`; do
     stem=`basename $lang .po`
     msguniq -w 200 -o ${dir}/${stem}.po ${dir}/${stem}.po
     msgmerge --no-fuzzy-matching -w 200 -o ${dir}/${stem}.po.tmp ${dir}/${stem}.po $1/templates/LC_MESSAGES/${stem}.pot
-    mv ${dir}/${stem}.po.tmp ${dir}/${stem}.po
+    # Remove obsolete strings
+    msgattrib --output-file=${dir}/${stem}.po -w 200 --no-obsolete ${dir}/${stem}.po.tmp
+    rm ${dir}/${stem}.po.tmp
 done
 
 # Optionally auto-localize our test locale db-LB


### PR DESCRIPTION
Output looks correct from a [test here](https://github.com/mozilla/fxa-content-server-l10n/pull/638)

Turns out we have a few… (-200k lines) 😨 