### PR TITLE
Update string across locales to include 'br' class

### DIFF
--- a/locale/ar/LC_MESSAGES/client.po
+++ b/locale/ar/LC_MESSAGES/client.po
@@ -1500,7 +1500,7 @@ msgid "Repeat password"
 msgstr "كرر كلمة السرّ"
 
 #: .es5/templates/sign_up_password.mustache:6
-msgid "You need this password to access any encrypted data you store with us.<br/>A reset means potentially losing data like passwords and bookmarks."
+msgid "You need this password to access any encrypted data you store with us.<br class=\"mb-3\">A reset means potentially losing data like passwords and bookmarks."
 msgstr ""
 
 #: .es5/templates/sign_up_password.mustache:7

--- a/locale/ast/LC_MESSAGES/client.po
+++ b/locale/ast/LC_MESSAGES/client.po
@@ -1501,7 +1501,7 @@ msgid "Repeat password"
 msgstr ""
 
 #: .es5/templates/sign_up_password.mustache:6
-msgid "You need this password to access any encrypted data you store with us.<br/>A reset means potentially losing data like passwords and bookmarks."
+msgid "You need this password to access any encrypted data you store with us.<br class=\"mb-3\">A reset means potentially losing data like passwords and bookmarks."
 msgstr ""
 
 #: .es5/templates/sign_up_password.mustache:7

--- a/locale/az/LC_MESSAGES/client.po
+++ b/locale/az/LC_MESSAGES/client.po
@@ -1504,7 +1504,7 @@ msgid "Repeat password"
 msgstr "Parolu sıfırla"
 
 #: .es5/templates/sign_up_password.mustache:6
-msgid "You need this password to access any encrypted data you store with us.<br/>A reset means potentially losing data like passwords and bookmarks."
+msgid "You need this password to access any encrypted data you store with us.<br class=\"mb-3\">A reset means potentially losing data like passwords and bookmarks."
 msgstr ""
 
 #: .es5/templates/sign_up_password.mustache:7

--- a/locale/be/LC_MESSAGES/client.po
+++ b/locale/be/LC_MESSAGES/client.po
@@ -1506,8 +1506,8 @@ msgid "Repeat password"
 msgstr "Паўтарыць пароль"
 
 #: .es5/templates/sign_up_password.mustache:6
-msgid "You need this password to access any encrypted data you store with us.<br/>A reset means potentially losing data like passwords and bookmarks."
-msgstr "Вам патрэбен гэты пароль для доступу да любых зашыфраваных дадзеных, якія вы захоўваеце ў нас.<br/>Скід азначае магчымую страту дадзеных, такіх як паролі і закладкі."
+msgid "You need this password to access any encrypted data you store with us.<br class=\"mb-3\">A reset means potentially losing data like passwords and bookmarks."
+msgstr "Вам патрэбен гэты пароль для доступу да любых зашыфраваных дадзеных, якія вы захоўваеце ў нас.<br class=\"mb-3\">Скід азначае магчымую страту дадзеных, такіх як паролі і закладкі."
 
 #: .es5/templates/sign_up_password.mustache:7
 msgid "Practical knowledge is coming to your inbox. Sign up for more:"

--- a/locale/bg/LC_MESSAGES/client.po
+++ b/locale/bg/LC_MESSAGES/client.po
@@ -1502,7 +1502,7 @@ msgid "Repeat password"
 msgstr "Повторете паролата"
 
 #: .es5/templates/sign_up_password.mustache:6
-msgid "You need this password to access any encrypted data you store with us.<br/>A reset means potentially losing data like passwords and bookmarks."
+msgid "You need this password to access any encrypted data you store with us.<br class=\"mb-3\">A reset means potentially losing data like passwords and bookmarks."
 msgstr ""
 
 #: .es5/templates/sign_up_password.mustache:7

--- a/locale/bn/LC_MESSAGES/client.po
+++ b/locale/bn/LC_MESSAGES/client.po
@@ -1501,7 +1501,7 @@ msgid "Repeat password"
 msgstr "পুনরায় পাসওয়ার্ড দিন"
 
 #: .es5/templates/sign_up_password.mustache:6
-msgid "You need this password to access any encrypted data you store with us.<br/>A reset means potentially losing data like passwords and bookmarks."
+msgid "You need this password to access any encrypted data you store with us.<br class=\"mb-3\">A reset means potentially losing data like passwords and bookmarks."
 msgstr ""
 
 #: .es5/templates/sign_up_password.mustache:7

--- a/locale/bs/LC_MESSAGES/client.po
+++ b/locale/bs/LC_MESSAGES/client.po
@@ -1501,7 +1501,7 @@ msgid "Repeat password"
 msgstr "Ponovi lozinku"
 
 #: .es5/templates/sign_up_password.mustache:6
-msgid "You need this password to access any encrypted data you store with us.<br/>A reset means potentially losing data like passwords and bookmarks."
+msgid "You need this password to access any encrypted data you store with us.<br class=\"mb-3\">A reset means potentially losing data like passwords and bookmarks."
 msgstr ""
 
 #: .es5/templates/sign_up_password.mustache:7

--- a/locale/ca/LC_MESSAGES/client.po
+++ b/locale/ca/LC_MESSAGES/client.po
@@ -1500,7 +1500,7 @@ msgid "Repeat password"
 msgstr "Repetiu la contrasenya"
 
 #: .es5/templates/sign_up_password.mustache:6
-msgid "You need this password to access any encrypted data you store with us.<br/>A reset means potentially losing data like passwords and bookmarks."
+msgid "You need this password to access any encrypted data you store with us.<br class=\"mb-3\">A reset means potentially losing data like passwords and bookmarks."
 msgstr ""
 
 #: .es5/templates/sign_up_password.mustache:7

--- a/locale/cak/LC_MESSAGES/client.po
+++ b/locale/cak/LC_MESSAGES/client.po
@@ -1503,9 +1503,9 @@ msgid "Repeat password"
 msgstr "Tikamulüx ewan tzij"
 
 #: .es5/templates/sign_up_password.mustache:6
-msgid "You need this password to access any encrypted data you store with us.<br/>A reset means potentially losing data like passwords and bookmarks."
+msgid "You need this password to access any encrypted data you store with us.<br class=\"mb-3\">A reset means potentially losing data like passwords and bookmarks."
 msgstr ""
-"Rajowaxik chawe re ewan tzij re' richin yatok pa jun tzij ewan rusik'ixik, ri ayakon kan qik'in.<br/>Toq nitzolïx chik nuq'ajuj chi yesach ri taq tzij achi'el ewan taq tzij chuqa' taq yaketal."
+"Rajowaxik chawe re ewan tzij re' richin yatok pa jun tzij ewan rusik'ixik, ri ayakon kan qik'in<br class=\"mb-3\">Toq nitzolïx chik nuq'ajuj chi yesach ri taq tzij achi'el ewan taq tzij chuqa' taq yaketal."
 
 #: .es5/templates/sign_up_password.mustache:7
 msgid "Practical knowledge is coming to your inbox. Sign up for more:"

--- a/locale/cs/LC_MESSAGES/client.po
+++ b/locale/cs/LC_MESSAGES/client.po
@@ -1503,8 +1503,8 @@ msgid "Repeat password"
 msgstr "Zopakujte heslo"
 
 #: .es5/templates/sign_up_password.mustache:6
-msgid "You need this password to access any encrypted data you store with us.<br/>A reset means potentially losing data like passwords and bookmarks."
-msgstr "Toto heslo budete potřebovat pro přístup ke všech šifrovaným datům, které si u nás uložíte.<br/>Při jeho obnovení může dojít ke ztrátě všech těchto dat včetně hesel nebo záložek."
+msgid "You need this password to access any encrypted data you store with us.<br class=\"mb-3\">A reset means potentially losing data like passwords and bookmarks."
+msgstr "Toto heslo budete potřebovat pro přístup ke všech šifrovaným datům, které si u nás uložíte.<br class=\"mb-3\">Při jeho obnovení může dojít ke ztrátě všech těchto dat včetně hesel nebo záložek."
 
 #: .es5/templates/sign_up_password.mustache:7
 msgid "Practical knowledge is coming to your inbox. Sign up for more:"

--- a/locale/cy/LC_MESSAGES/client.po
+++ b/locale/cy/LC_MESSAGES/client.po
@@ -1511,9 +1511,9 @@ msgid "Repeat password"
 msgstr "Ailadrodd y cyfrinair"
 
 #: .es5/templates/sign_up_password.mustache:6
-msgid "You need this password to access any encrypted data you store with us.<br/>A reset means potentially losing data like passwords and bookmarks."
+msgid "You need this password to access any encrypted data you store with us.<br class=\"mb-3\">A reset means potentially losing data like passwords and bookmarks."
 msgstr ""
-"Mae angen y cyfrinair hwn arnoch i gael mynediad at unrhyw ddata wedi'i amgryptio rydych chi'n ei storio gyda ni.<br/>Mae ailosod, o bosibl, yn golygu colli data fel cyfrineiriau a nodau tudalen."
+"Mae angen y cyfrinair hwn arnoch i gael mynediad at unrhyw ddata wedi'i amgryptio rydych chi'n ei storio gyda ni.<br class=\"mb-3\">Mae ailosod, o bosibl, yn golygu colli data fel cyfrineiriau a nodau tudalen."
 
 #: .es5/templates/sign_up_password.mustache:7
 msgid "Practical knowledge is coming to your inbox. Sign up for more:"

--- a/locale/da/LC_MESSAGES/client.po
+++ b/locale/da/LC_MESSAGES/client.po
@@ -1509,8 +1509,8 @@ msgid "Repeat password"
 msgstr "Gentag adgangskode"
 
 #: .es5/templates/sign_up_password.mustache:6
-msgid "You need this password to access any encrypted data you store with us.<br/>A reset means potentially losing data like passwords and bookmarks."
-msgstr "Du skal bruge denne adgangskode for at få adgang til de krypterede data, du gemmer hos os.<br/>En nulstilling kan medføre tab af data som fx adgangskoder og bogmærker."
+msgid "You need this password to access any encrypted data you store with us.<br class=\"mb-3\">A reset means potentially losing data like passwords and bookmarks."
+msgstr "Du skal bruge denne adgangskode for at få adgang til de krypterede data, du gemmer hos os.<br class=\"mb-3\">En nulstilling kan medføre tab af data som fx adgangskoder og bogmærker."
 
 #: .es5/templates/sign_up_password.mustache:7
 msgid "Practical knowledge is coming to your inbox. Sign up for more:"

--- a/locale/de/LC_MESSAGES/client.po
+++ b/locale/de/LC_MESSAGES/client.po
@@ -1514,9 +1514,9 @@ msgid "Repeat password"
 msgstr "Passwort wiederholen"
 
 #: .es5/templates/sign_up_password.mustache:6
-msgid "You need this password to access any encrypted data you store with us.<br/>A reset means potentially losing data like passwords and bookmarks."
+msgid "You need this password to access any encrypted data you store with us.<br class=\"mb-3\">A reset means potentially losing data like passwords and bookmarks."
 msgstr ""
-"Sie benötigen dieses Passwort, um auf verschlüsselte Daten zuzugreifen, die Sie bei uns speichern.<br/>Wenn Sie es zurücksetzen, gehen möglicherweise Daten wie Passwörter und Lesezeichen verloren."
+"Sie benötigen dieses Passwort, um auf verschlüsselte Daten zuzugreifen, die Sie bei uns speichern.<br class=\"mb-3\">Wenn Sie es zurücksetzen, gehen möglicherweise Daten wie Passwörter und Lesezeichen verloren."
 
 #: .es5/templates/sign_up_password.mustache:7
 msgid "Practical knowledge is coming to your inbox. Sign up for more:"

--- a/locale/dsb/LC_MESSAGES/client.po
+++ b/locale/dsb/LC_MESSAGES/client.po
@@ -1512,8 +1512,8 @@ msgid "Repeat password"
 msgstr "Gronidło wóspjetowaś"
 
 #: .es5/templates/sign_up_password.mustache:6
-msgid "You need this password to access any encrypted data you store with us.<br/>A reset means potentially losing data like passwords and bookmarks."
-msgstr "Trjebaśo toś to gronidło za pśistup ku koděrowanym datam, kótarež pla nas składujośo.<br/>Gaž slědk stajaśo, se snaź daty ako gronidło a cytańske znamjenja zgubuju."
+msgid "You need this password to access any encrypted data you store with us.<br class=\"mb-3\">A reset means potentially losing data like passwords and bookmarks."
+msgstr "Trjebaśo toś to gronidło za pśistup ku koděrowanym datam, kótarež pla nas składujośo.<br class=\"mb-3\">Gaž slědk stajaśo, se snaź daty ako gronidło a cytańske znamjenja zgubuju."
 
 #: .es5/templates/sign_up_password.mustache:7
 msgid "Practical knowledge is coming to your inbox. Sign up for more:"

--- a/locale/el/LC_MESSAGES/client.po
+++ b/locale/el/LC_MESSAGES/client.po
@@ -1514,9 +1514,9 @@ msgid "Repeat password"
 msgstr "Επανάληψη κωδικού πρόσβασης"
 
 #: .es5/templates/sign_up_password.mustache:6
-msgid "You need this password to access any encrypted data you store with us.<br/>A reset means potentially losing data like passwords and bookmarks."
+msgid "You need this password to access any encrypted data you store with us.<br class=\"mb-3\">A reset means potentially losing data like passwords and bookmarks."
 msgstr ""
-"Χρειάζεστε αυτό τον κωδικό πρόσβασης για πρόσβαση σε κρυπτογραφημένα δεδομένα που αποθηκεύετε σε εμάς.<br/>Επαναφορά, σημαίνει ενδεχομένως απώλεια δεδομένων, όπως κωδικοί πρόσβασης και "
+"Χρειάζεστε αυτό τον κωδικό πρόσβασης για πρόσβαση σε κρυπτογραφημένα δεδομένα που αποθηκεύετε σε εμάς.<br class=\"mb-3\">Επαναφορά, σημαίνει ενδεχομένως απώλεια δεδομένων, όπως κωδικοί πρόσβασης και "
 "σελιδοδείκτες."
 
 #: .es5/templates/sign_up_password.mustache:7

--- a/locale/en/LC_MESSAGES/client.po
+++ b/locale/en/LC_MESSAGES/client.po
@@ -1499,7 +1499,7 @@ msgid "Repeat password"
 msgstr ""
 
 #: .es5/templates/sign_up_password.mustache:6
-msgid "You need this password to access any encrypted data you store with us.<br/>A reset means potentially losing data like passwords and bookmarks."
+msgid "You need this password to access any encrypted data you store with us.<br class=\"mb-3\">A reset means potentially losing data like passwords and bookmarks."
 msgstr ""
 
 #: .es5/templates/sign_up_password.mustache:7

--- a/locale/en_CA/LC_MESSAGES/client.po
+++ b/locale/en_CA/LC_MESSAGES/client.po
@@ -1511,8 +1511,8 @@ msgid "Repeat password"
 msgstr "Repeat password"
 
 #: .es5/templates/sign_up_password.mustache:6
-msgid "You need this password to access any encrypted data you store with us.<br/>A reset means potentially losing data like passwords and bookmarks."
-msgstr "You need this password to access any encrypted data you store with us.<br/>A reset means potentially losing data like passwords and bookmarks."
+msgid "You need this password to access any encrypted data you store with us.<br class=\"mb-3\">A reset means potentially losing data like passwords and bookmarks."
+msgstr "You need this password to access any encrypted data you store with us.<br class=\"mb-3\">A reset means potentially losing data like passwords and bookmarks."
 
 #: .es5/templates/sign_up_password.mustache:7
 msgid "Practical knowledge is coming to your inbox. Sign up for more:"

--- a/locale/en_GB/LC_MESSAGES/client.po
+++ b/locale/en_GB/LC_MESSAGES/client.po
@@ -1508,8 +1508,8 @@ msgid "Repeat password"
 msgstr "Repeat password"
 
 #: .es5/templates/sign_up_password.mustache:6
-msgid "You need this password to access any encrypted data you store with us.<br/>A reset means potentially losing data like passwords and bookmarks."
-msgstr "You need this password to access any encrypted data you store with us.<br/>A reset means potentially losing data like passwords and bookmarks."
+msgid "You need this password to access any encrypted data you store with us.<br class=\"mb-3\">A reset means potentially losing data like passwords and bookmarks."
+msgstr "You need this password to access any encrypted data you store with us.<br class=\"mb-3\">A reset means potentially losing data like passwords and bookmarks."
 
 #: .es5/templates/sign_up_password.mustache:7
 msgid "Practical knowledge is coming to your inbox. Sign up for more:"

--- a/locale/en_US/LC_MESSAGES/client.po
+++ b/locale/en_US/LC_MESSAGES/client.po
@@ -1495,7 +1495,7 @@ msgid "Repeat password"
 msgstr ""
 
 #: .es5/templates/sign_up_password.mustache:6
-msgid "You need this password to access any encrypted data you store with us.<br/>A reset means potentially losing data like passwords and bookmarks."
+msgid "You need this password to access any encrypted data you store with us.<br class=\"mb-3\">A reset means potentially losing data like passwords and bookmarks."
 msgstr ""
 
 #: .es5/templates/sign_up_password.mustache:7

--- a/locale/es/LC_MESSAGES/client.po
+++ b/locale/es/LC_MESSAGES/client.po
@@ -1508,8 +1508,8 @@ msgid "Repeat password"
 msgstr "Repetir contraseña"
 
 #: .es5/templates/sign_up_password.mustache:6
-msgid "You need this password to access any encrypted data you store with us.<br/>A reset means potentially losing data like passwords and bookmarks."
-msgstr "Necesitas esta contraseña para acceder a cualquier dato cifrado que almacenes con nosotros.<br/>Un restablecimiento podría provocar la pérdida de datos, como contraseñas y marcadores."
+msgid "You need this password to access any encrypted data you store with us.<br class=\"mb-3\">A reset means potentially losing data like passwords and bookmarks."
+msgstr "Necesitas esta contraseña para acceder a cualquier dato cifrado que almacenes con nosotros.<br class=\"mb-3\">Un restablecimiento podría provocar la pérdida de datos, como contraseñas y marcadores."
 
 #: .es5/templates/sign_up_password.mustache:7
 msgid "Practical knowledge is coming to your inbox. Sign up for more:"

--- a/locale/es_AR/LC_MESSAGES/client.po
+++ b/locale/es_AR/LC_MESSAGES/client.po
@@ -1513,8 +1513,8 @@ msgid "Repeat password"
 msgstr "Repetí la contraseña"
 
 #: .es5/templates/sign_up_password.mustache:6
-msgid "You need this password to access any encrypted data you store with us.<br/>A reset means potentially losing data like passwords and bookmarks."
-msgstr "Necesitás esta contraseña para acceder a cualquier dato encriptado que almacenaste con nosotros.<br/>Un restablecimiento significa la pérdida potencial de datos como contraseñas y marcadores."
+msgid "You need this password to access any encrypted data you store with us.<br class=\"mb-3\">A reset means potentially losing data like passwords and bookmarks."
+msgstr "Necesitás esta contraseña para acceder a cualquier dato encriptado que almacenaste con nosotros.<br class=\"mb-3\">Un restablecimiento significa la pérdida potencial de datos como contraseñas y marcadores."
 
 #: .es5/templates/sign_up_password.mustache:7
 msgid "Practical knowledge is coming to your inbox. Sign up for more:"

--- a/locale/es_CL/LC_MESSAGES/client.po
+++ b/locale/es_CL/LC_MESSAGES/client.po
@@ -1513,8 +1513,8 @@ msgid "Repeat password"
 msgstr "Repertir contraseña"
 
 #: .es5/templates/sign_up_password.mustache:6
-msgid "You need this password to access any encrypted data you store with us.<br/>A reset means potentially losing data like passwords and bookmarks."
-msgstr "Necesitas esta contraseña para acceder a todo dato cifrado que almacenes con nosotros.<br/>Resetearla podría traducirse en la pérdida de datos como contraseñas y marcadores."
+msgid "You need this password to access any encrypted data you store with us.<br class=\"mb-3\">A reset means potentially losing data like passwords and bookmarks."
+msgstr "Necesitas esta contraseña para acceder a todo dato cifrado que almacenes con nosotros.<br class=\"mb-3\">Resetearla podría traducirse en la pérdida de datos como contraseñas y marcadores."
 
 #: .es5/templates/sign_up_password.mustache:7
 msgid "Practical knowledge is coming to your inbox. Sign up for more:"

--- a/locale/es_ES/LC_MESSAGES/client.po
+++ b/locale/es_ES/LC_MESSAGES/client.po
@@ -1508,8 +1508,8 @@ msgid "Repeat password"
 msgstr "Repetir contraseña"
 
 #: .es5/templates/sign_up_password.mustache:6
-msgid "You need this password to access any encrypted data you store with us.<br/>A reset means potentially losing data like passwords and bookmarks."
-msgstr "Necesitas esta contraseña para acceder a cualquier dato cifrado que almacenes con nosotros.<br/>Un restablecimiento podría provocar la pérdida de datos, como contraseñas y marcadores."
+msgid "You need this password to access any encrypted data you store with us.<br class=\"mb-3\">A reset means potentially losing data like passwords and bookmarks."
+msgstr "Necesitas esta contraseña para acceder a cualquier dato cifrado que almacenes con nosotros.<br class=\"mb-3\">Un restablecimiento podría provocar la pérdida de datos, como contraseñas y marcadores."
 
 #: .es5/templates/sign_up_password.mustache:7
 msgid "Practical knowledge is coming to your inbox. Sign up for more:"

--- a/locale/es_MX/LC_MESSAGES/client.po
+++ b/locale/es_MX/LC_MESSAGES/client.po
@@ -1510,9 +1510,9 @@ msgid "Repeat password"
 msgstr "Repitir contraseña"
 
 #: .es5/templates/sign_up_password.mustache:6
-msgid "You need this password to access any encrypted data you store with us.<br/>A reset means potentially losing data like passwords and bookmarks."
+msgid "You need this password to access any encrypted data you store with us.<br class=\"mb-3\">A reset means potentially losing data like passwords and bookmarks."
 msgstr ""
-"Necesitas de esta contraseña para acceder a cualquier dato encriptado que almacenaste con nosotros,<br/>Un restablecimiento significa la pérdida potencial de datos como contraseñas y marcadores."
+"Necesitas de esta contraseña para acceder a cualquier dato encriptado que almacenaste con nosotros,<br class=\"mb-3\">Un restablecimiento significa la pérdida potencial de datos como contraseñas y marcadores."
 
 #: .es5/templates/sign_up_password.mustache:7
 msgid "Practical knowledge is coming to your inbox. Sign up for more:"

--- a/locale/et/LC_MESSAGES/client.po
+++ b/locale/et/LC_MESSAGES/client.po
@@ -1506,8 +1506,8 @@ msgid "Repeat password"
 msgstr "Korda parooli"
 
 #: .es5/templates/sign_up_password.mustache:6
-msgid "You need this password to access any encrypted data you store with us.<br/>A reset means potentially losing data like passwords and bookmarks."
-msgstr "Sa vajad seda parooli, et pääseda ligi meie juures salvestatud krüptitud andmetele.<br/>Lähtestamine tähendab andmete, nagu paroolid ja järjehoidjad, potentsiaalset kaotamist."
+msgid "You need this password to access any encrypted data you store with us.<br class=\"mb-3\">A reset means potentially losing data like passwords and bookmarks."
+msgstr "Sa vajad seda parooli, et pääseda ligi meie juures salvestatud krüptitud andmetele.<br class=\"mb-3\">Lähtestamine tähendab andmete, nagu paroolid ja järjehoidjad, potentsiaalset kaotamist."
 
 #: .es5/templates/sign_up_password.mustache:7
 msgid "Practical knowledge is coming to your inbox. Sign up for more:"

--- a/locale/eu/LC_MESSAGES/client.po
+++ b/locale/eu/LC_MESSAGES/client.po
@@ -1504,8 +1504,8 @@ msgid "Repeat password"
 msgstr "Errepikatu pasahitza"
 
 #: .es5/templates/sign_up_password.mustache:6
-msgid "You need this password to access any encrypted data you store with us.<br/>A reset means potentially losing data like passwords and bookmarks."
-msgstr "Gurekin gordetako zifratutako datu orotarako sarbidea izateko behar duzu pasahitz hau.<br/>Pasahitza berrezarriz gero, ziurrenik pasahitzak eta laster-markak galdu egingo dira."
+msgid "You need this password to access any encrypted data you store with us.<br class=\"mb-3\">A reset means potentially losing data like passwords and bookmarks."
+msgstr "Gurekin gordetako zifratutako datu orotarako sarbidea izateko behar duzu pasahitz hau.<br class=\"mb-3\">Pasahitza berrezarriz gero, ziurrenik pasahitzak eta laster-markak galdu egingo dira."
 
 #: .es5/templates/sign_up_password.mustache:7
 msgid "Practical knowledge is coming to your inbox. Sign up for more:"

--- a/locale/fa/LC_MESSAGES/client.po
+++ b/locale/fa/LC_MESSAGES/client.po
@@ -1504,8 +1504,8 @@ msgid "Repeat password"
 msgstr "تکرار گذرواژه"
 
 #: .es5/templates/sign_up_password.mustache:6
-msgid "You need this password to access any encrypted data you store with us.<br/>A reset means potentially losing data like passwords and bookmarks."
-msgstr "برای دسترسی به هر نوع اطلاعات رمزنگاری شده‌ای ذخیره می‌کنیم، نیاز به این گذرواژه دارید.<br/>تغییر گذرواژه به معنی از دست دادن اطلاعات مانند گذرواژه‌ها و نشانک‌ها خواهد بود."
+msgid "You need this password to access any encrypted data you store with us.<br class=\"mb-3\">A reset means potentially losing data like passwords and bookmarks."
+msgstr "برای دسترسی به هر نوع اطلاعات رمزنگاری شده‌ای ذخیره می‌کنیم، نیاز به این گذرواژه دارید.<br class=\"mb-3\">تغییر گذرواژه به معنی از دست دادن اطلاعات مانند گذرواژه‌ها و نشانک‌ها خواهد بود."
 
 #: .es5/templates/sign_up_password.mustache:7
 msgid "Practical knowledge is coming to your inbox. Sign up for more:"

--- a/locale/ff/LC_MESSAGES/client.po
+++ b/locale/ff/LC_MESSAGES/client.po
@@ -1501,7 +1501,7 @@ msgid "Repeat password"
 msgstr "Naattin finnde"
 
 #: .es5/templates/sign_up_password.mustache:6
-msgid "You need this password to access any encrypted data you store with us.<br/>A reset means potentially losing data like passwords and bookmarks."
+msgid "You need this password to access any encrypted data you store with us.<br class=\"mb-3\">A reset means potentially losing data like passwords and bookmarks."
 msgstr ""
 
 #: .es5/templates/sign_up_password.mustache:7

--- a/locale/fi/LC_MESSAGES/client.po
+++ b/locale/fi/LC_MESSAGES/client.po
@@ -1501,8 +1501,8 @@ msgid "Repeat password"
 msgstr "Toista salasana"
 
 #: .es5/templates/sign_up_password.mustache:6
-msgid "You need this password to access any encrypted data you store with us.<br/>A reset means potentially losing data like passwords and bookmarks."
-msgstr "Tarvitset tätä salasanaa, jotta voit käyttää palveluihimme tallennettuja salattuja tietojasi.<br/>Nollaus tarkoittaa, että saatat menettää tietosi, kuten salasanat ja kirjanmerkit."
+msgid "You need this password to access any encrypted data you store with us.<br class=\"mb-3\">A reset means potentially losing data like passwords and bookmarks."
+msgstr "Tarvitset tätä salasanaa, jotta voit käyttää palveluihimme tallennettuja salattuja tietojasi.<br class=\"mb-3\">Nollaus tarkoittaa, että saatat menettää tietosi, kuten salasanat ja kirjanmerkit."
 
 #: .es5/templates/sign_up_password.mustache:7
 msgid "Practical knowledge is coming to your inbox. Sign up for more:"

--- a/locale/fr/LC_MESSAGES/client.po
+++ b/locale/fr/LC_MESSAGES/client.po
@@ -1510,9 +1510,9 @@ msgid "Repeat password"
 msgstr "Répéter le mot de passe"
 
 #: .es5/templates/sign_up_password.mustache:6
-msgid "You need this password to access any encrypted data you store with us.<br/>A reset means potentially losing data like passwords and bookmarks."
+msgid "You need this password to access any encrypted data you store with us.<br class=\"mb-3\">A reset means potentially losing data like passwords and bookmarks."
 msgstr ""
-"Vous avez besoin de ce mot de passe pour accéder aux données chiffrées que vous stockez chez nous.<br/>Le réinitialiser peut entraîner une perte de données telles que les mots de passe ou les "
+"Vous avez besoin de ce mot de passe pour accéder aux données chiffrées que vous stockez chez nous.<br class=\"mb-3\">Le réinitialiser peut entraîner une perte de données telles que les mots de passe ou les "
 "marque-pages."
 
 #: .es5/templates/sign_up_password.mustache:7

--- a/locale/fy/LC_MESSAGES/client.po
+++ b/locale/fy/LC_MESSAGES/client.po
@@ -1510,8 +1510,8 @@ msgid "Repeat password"
 msgstr "Nochris it wachtwurd"
 
 #: .es5/templates/sign_up_password.mustache:6
-msgid "You need this password to access any encrypted data you store with us.<br/>A reset means potentially losing data like passwords and bookmarks."
-msgstr "Jo hawwe dit wachtwurd nedich om tagong te krijen ta kodearre gegevens dy’t jo by ús bewarje.<br/>In nije inisjalisaasje betsjut mooglik ferlies fan gegevens lykas wachtwurden en blêdwizers."
+msgid "You need this password to access any encrypted data you store with us.<br class=\"mb-3\">A reset means potentially losing data like passwords and bookmarks."
+msgstr "Jo hawwe dit wachtwurd nedich om tagong te krijen ta kodearre gegevens dy’t jo by ús bewarje.<br class=\"mb-3\">In nije inisjalisaasje betsjut mooglik ferlies fan gegevens lykas wachtwurden en blêdwizers."
 
 #: .es5/templates/sign_up_password.mustache:7
 msgid "Practical knowledge is coming to your inbox. Sign up for more:"

--- a/locale/fy/LC_MESSAGES/client.po-e
+++ b/locale/fy/LC_MESSAGES/client.po-e
@@ -1467,8 +1467,8 @@ msgid "Repeat password"
 msgstr "Nochris it wachtwurd"
 
 #: .es5/templates/sign_up_password.mustache:9
-msgid "You need this password to access any encrypted data you store with us.<br/>A reset means potentially losing data like passwords and bookmarks."
-msgstr "Jo hawwe dit wachtwurd nedich om tagong te krijen ta kodearre gegevens dy't jo by ús bewarje.<br/>In nije inisjalisaasje betsjut mooglik ferlies fan gegevens lykas wachtwurden en blêdwizers."
+msgid "You need this password to access any encrypted data you store with us.<br class=\"mb-3\">A reset means potentially losing data like passwords and bookmarks."
+msgstr "Jo hawwe dit wachtwurd nedich om tagong te krijen ta kodearre gegevens dy't jo by ús bewarje.<br class=\"mb-3\">In nije inisjalisaasje betsjut mooglik ferlies fan gegevens lykas wachtwurden en blêdwizers."
 
 #: .es5/templates/sign_up_password.mustache:10
 msgid "Practical knowledge is coming to your inbox. Sign up for more:"

--- a/locale/fy_NL/LC_MESSAGES/client.po
+++ b/locale/fy_NL/LC_MESSAGES/client.po
@@ -1515,8 +1515,8 @@ msgid "Repeat password"
 msgstr "Nochris it wachtwurd"
 
 #: .es5/templates/sign_up_password.mustache:6
-msgid "You need this password to access any encrypted data you store with us.<br/>A reset means potentially losing data like passwords and bookmarks."
-msgstr "Jo hawwe dit wachtwurd nedich om tagong te krijen ta kodearre gegevens dy’t jo by ús bewarje.<br/>In nije inisjalisaasje betsjut mooglik ferlies fan gegevens lykas wachtwurden en blêdwizers."
+msgid "You need this password to access any encrypted data you store with us.<br class=\"mb-3\">A reset means potentially losing data like passwords and bookmarks."
+msgstr "Jo hawwe dit wachtwurd nedich om tagong te krijen ta kodearre gegevens dy’t jo by ús bewarje.<br class=\"mb-3\">In nije inisjalisaasje betsjut mooglik ferlies fan gegevens lykas wachtwurden en blêdwizers."
 
 #: .es5/templates/sign_up_password.mustache:7
 msgid "Practical knowledge is coming to your inbox. Sign up for more:"

--- a/locale/gd/LC_MESSAGES/client.po
+++ b/locale/gd/LC_MESSAGES/client.po
@@ -1507,9 +1507,9 @@ msgid "Repeat password"
 msgstr "Cuir am facal-faire a-steach a-rithist"
 
 #: .es5/templates/sign_up_password.mustache:6
-msgid "You need this password to access any encrypted data you store with us.<br/>A reset means potentially losing data like passwords and bookmarks."
+msgid "You need this password to access any encrypted data you store with us.<br class=\"mb-3\">A reset means potentially losing data like passwords and bookmarks."
 msgstr ""
-"Feumaidh tu am facal-faire seo airson cothrom fhaighinn air dàta crioptaichte agad san stòras againn.<br/>Ma nì thu ath-shuidheachadh, tha teans gun caill thu dàta mar fhaclan-faire agus comharran-"
+"Feumaidh tu am facal-faire seo airson cothrom fhaighinn air dàta crioptaichte agad san stòras againn.<br class=\"mb-3\">Ma nì thu ath-shuidheachadh, tha teans gun caill thu dàta mar fhaclan-faire agus comharran-"
 "lìn."
 
 #: .es5/templates/sign_up_password.mustache:7

--- a/locale/gl/LC_MESSAGES/client.po
+++ b/locale/gl/LC_MESSAGES/client.po
@@ -1499,7 +1499,7 @@ msgid "Repeat password"
 msgstr "Repetir contrasinal"
 
 #: .es5/templates/sign_up_password.mustache:6
-msgid "You need this password to access any encrypted data you store with us.<br/>A reset means potentially losing data like passwords and bookmarks."
+msgid "You need this password to access any encrypted data you store with us.<br class=\"mb-3\">A reset means potentially losing data like passwords and bookmarks."
 msgstr ""
 
 #: .es5/templates/sign_up_password.mustache:7

--- a/locale/gn/LC_MESSAGES/client.po
+++ b/locale/gn/LC_MESSAGES/client.po
@@ -1504,8 +1504,8 @@ msgid "Repeat password"
 msgstr "Emoingejey ñe’ẽñemi"
 
 #: .es5/templates/sign_up_password.mustache:6
-msgid "You need this password to access any encrypted data you store with us.<br/>A reset means potentially losing data like passwords and bookmarks."
-msgstr "Eikotevẽ ñe’ẽñemi eike hag̃ua mba’ekuaarã papapy embyatýva orendivépe. <br/>Eguerujeýramo, he’ise oguekuaaha ndehegui mba’ekuaarã ikatúva ñe’ẽñemi ha techaukaha."
+msgid "You need this password to access any encrypted data you store with us.<br class=\"mb-3\">A reset means potentially losing data like passwords and bookmarks."
+msgstr "Eikotevẽ ñe’ẽñemi eike hag̃ua mba’ekuaarã papapy embyatýva orendivépe. <br class=\"mb-3\">Eguerujeýramo, he’ise oguekuaaha ndehegui mba’ekuaarã ikatúva ñe’ẽñemi ha techaukaha."
 
 #: .es5/templates/sign_up_password.mustache:7
 msgid "Practical knowledge is coming to your inbox. Sign up for more:"

--- a/locale/he/LC_MESSAGES/client.po
+++ b/locale/he/LC_MESSAGES/client.po
@@ -1507,8 +1507,8 @@ msgid "Repeat password"
 msgstr "חזרה על הססמה"
 
 #: .es5/templates/sign_up_password.mustache:6
-msgid "You need this password to access any encrypted data you store with us.<br/>A reset means potentially losing data like passwords and bookmarks."
-msgstr "הססמה הזו תשמש אותך כדי לגשת לכל הנתונים המוצפנים שלך המאוחסנים אצלנו.<br/>איפוס הססמה עלול לגרום לאיבוד נתונים כמו ססמאות וסימניות."
+msgid "You need this password to access any encrypted data you store with us.<br class=\"mb-3\">A reset means potentially losing data like passwords and bookmarks."
+msgstr "הססמה הזו תשמש אותך כדי לגשת לכל הנתונים המוצפנים שלך המאוחסנים אצלנו.<br class=\"mb-3\">איפוס הססמה עלול לגרום לאיבוד נתונים כמו ססמאות וסימניות."
 
 #: .es5/templates/sign_up_password.mustache:7
 msgid "Practical knowledge is coming to your inbox. Sign up for more:"

--- a/locale/hi/LC_MESSAGES/client.po
+++ b/locale/hi/LC_MESSAGES/client.po
@@ -1502,7 +1502,7 @@ msgid "Repeat password"
 msgstr "कूटशब्द आवृत्ति"
 
 #: .es5/templates/sign_up_password.mustache:6
-msgid "You need this password to access any encrypted data you store with us.<br/>A reset means potentially losing data like passwords and bookmarks."
+msgid "You need this password to access any encrypted data you store with us.<br class=\"mb-3\">A reset means potentially losing data like passwords and bookmarks."
 msgstr ""
 
 #: .es5/templates/sign_up_password.mustache:7

--- a/locale/hi/LC_MESSAGES/client.po-e
+++ b/locale/hi/LC_MESSAGES/client.po-e
@@ -1453,7 +1453,7 @@ msgid "Repeat password"
 msgstr "कूटशब्द आवृत्ति"
 
 #: .es5/templates/sign_up_password.mustache:9
-msgid "You need this password to access any encrypted data you store with us.<br/>A reset means potentially losing data like passwords and bookmarks."
+msgid "You need this password to access any encrypted data you store with us.<br class=\"mb-3\">A reset means potentially losing data like passwords and bookmarks."
 msgstr ""
 
 #: .es5/templates/sign_up_password.mustache:10

--- a/locale/hi_IN/LC_MESSAGES/client.po
+++ b/locale/hi_IN/LC_MESSAGES/client.po
@@ -1502,7 +1502,7 @@ msgid "Repeat password"
 msgstr "कूटशब्द आवृत्ति"
 
 #: .es5/templates/sign_up_password.mustache:6
-msgid "You need this password to access any encrypted data you store with us.<br/>A reset means potentially losing data like passwords and bookmarks."
+msgid "You need this password to access any encrypted data you store with us.<br class=\"mb-3\">A reset means potentially losing data like passwords and bookmarks."
 msgstr ""
 
 #: .es5/templates/sign_up_password.mustache:7

--- a/locale/hr/LC_MESSAGES/client.po
+++ b/locale/hr/LC_MESSAGES/client.po
@@ -1503,8 +1503,8 @@ msgid "Repeat password"
 msgstr "Ponovi lozinku"
 
 #: .es5/templates/sign_up_password.mustache:6
-msgid "You need this password to access any encrypted data you store with us.<br/>A reset means potentially losing data like passwords and bookmarks."
-msgstr "Ovu lozinku trebaš za pristupanje bilo kojim šifriranim podatcima koje pohranjujemo za tebe.<br/>Ponovno postavljanje može rezultirati gubitkom podataka, kao što su lozinke i zabilješke."
+msgid "You need this password to access any encrypted data you store with us.<br class=\"mb-3\">A reset means potentially losing data like passwords and bookmarks."
+msgstr "Ovu lozinku trebaš za pristupanje bilo kojim šifriranim podatcima koje pohranjujemo za tebe.<br class=\"mb-3\">Ponovno postavljanje može rezultirati gubitkom podataka, kao što su lozinke i zabilješke."
 
 #: .es5/templates/sign_up_password.mustache:7
 msgid "Practical knowledge is coming to your inbox. Sign up for more:"

--- a/locale/hsb/LC_MESSAGES/client.po
+++ b/locale/hsb/LC_MESSAGES/client.po
@@ -1512,8 +1512,8 @@ msgid "Repeat password"
 msgstr "Hesło wospjetować"
 
 #: .es5/templates/sign_up_password.mustache:6
-msgid "You need this password to access any encrypted data you store with us.<br/>A reset means potentially losing data like passwords and bookmarks."
-msgstr "Trjebaće tute hesło za přistup k zaklučowanym datam, kotrež pola nas składujeće.<br/>Hdyž wróćo stajeće, so snano daty kaž hesła a zapołožki zhubja."
+msgid "You need this password to access any encrypted data you store with us.<br class=\"mb-3\">A reset means potentially losing data like passwords and bookmarks."
+msgstr "Trjebaće tute hesło za přistup k zaklučowanym datam, kotrež pola nas składujeće.<br class=\"mb-3\">Hdyž wróćo stajeće, so snano daty kaž hesła a zapołožki zhubja."
 
 #: .es5/templates/sign_up_password.mustache:7
 msgid "Practical knowledge is coming to your inbox. Sign up for more:"

--- a/locale/hu/LC_MESSAGES/client.po
+++ b/locale/hu/LC_MESSAGES/client.po
@@ -1513,8 +1513,8 @@ msgid "Repeat password"
 msgstr "Jelszó megismétlése"
 
 #: .es5/templates/sign_up_password.mustache:6
-msgid "You need this password to access any encrypted data you store with us.<br/>A reset means potentially losing data like passwords and bookmarks."
-msgstr "Azért van szüksége erre a jelszóra, hogy hozzáférjen a nálunk tárolt titkosított adataihoz.<br/>A visszaállítás azt jelenti, hogy elvesztheti a jelszavait és könyvjelzőit."
+msgid "You need this password to access any encrypted data you store with us.<br class=\"mb-3\">A reset means potentially losing data like passwords and bookmarks."
+msgstr "Azért van szüksége erre a jelszóra, hogy hozzáférjen a nálunk tárolt titkosított adataihoz.<br class=\"mb-3\">A visszaállítás azt jelenti, hogy elvesztheti a jelszavait és könyvjelzőit."
 
 #: .es5/templates/sign_up_password.mustache:7
 msgid "Practical knowledge is coming to your inbox. Sign up for more:"

--- a/locale/hus/LC_MESSAGES/client.po
+++ b/locale/hus/LC_MESSAGES/client.po
@@ -1496,7 +1496,7 @@ msgid "Repeat password"
 msgstr ""
 
 #: .es5/templates/sign_up_password.mustache:6
-msgid "You need this password to access any encrypted data you store with us.<br/>A reset means potentially losing data like passwords and bookmarks."
+msgid "You need this password to access any encrypted data you store with us.<br class=\"mb-3\">A reset means potentially losing data like passwords and bookmarks."
 msgstr ""
 
 #: .es5/templates/sign_up_password.mustache:7

--- a/locale/hy_AM/LC_MESSAGES/client.po
+++ b/locale/hy_AM/LC_MESSAGES/client.po
@@ -1504,9 +1504,9 @@ msgid "Repeat password"
 msgstr "Պատճենել գաղտնաբառը"
 
 #: .es5/templates/sign_up_password.mustache:6
-msgid "You need this password to access any encrypted data you store with us.<br/>A reset means potentially losing data like passwords and bookmarks."
+msgid "You need this password to access any encrypted data you store with us.<br class=\"mb-3\">A reset means potentially losing data like passwords and bookmarks."
 msgstr ""
-"Ձեզ հարկավոր է այս գաղտնաբառը՝ մեզ հետ պահվող ցանկացած գաղտնագրված տվյալներ մուտք ունենալու համար։ <br/> գաղտնաբառի վերագործարկումը կհանգեցնի տվյալների կորստի հավանականության, ինչպիսիք են "
+"Ձեզ հարկավոր է այս գաղտնաբառը՝ մեզ հետ պահվող ցանկացած գաղտնագրված տվյալներ մուտք ունենալու համար։ <br class=\"mb-3\"> գաղտնաբառի վերագործարկումը կհանգեցնի տվյալների կորստի հավանականության, ինչպիսիք են "
 "գաղտնաբառերը և էջանիշերը։"
 
 #: .es5/templates/sign_up_password.mustache:7

--- a/locale/ia/LC_MESSAGES/client.po
+++ b/locale/ia/LC_MESSAGES/client.po
@@ -1510,8 +1510,8 @@ msgid "Repeat password"
 msgstr "Repete le contrasigno"
 
 #: .es5/templates/sign_up_password.mustache:6
-msgid "You need this password to access any encrypted data you store with us.<br/>A reset means potentially losing data like passwords and bookmarks."
-msgstr "Iste contrasigno es necessari pro acceder al datos cryptate que tu immagazina in nostre systemas.<br/>Si tu reinitialisa le contrasigno, tu pote perder datos como contrasignos e marcapaginas."
+msgid "You need this password to access any encrypted data you store with us.<br class=\"mb-3\">A reset means potentially losing data like passwords and bookmarks."
+msgstr "Iste contrasigno es necessari pro acceder al datos cryptate que tu immagazina in nostre systemas.<br class=\"mb-3\">Si tu reinitialisa le contrasigno, tu pote perder datos como contrasignos e marcapaginas."
 
 #: .es5/templates/sign_up_password.mustache:7
 msgid "Practical knowledge is coming to your inbox. Sign up for more:"

--- a/locale/id/LC_MESSAGES/client.po
+++ b/locale/id/LC_MESSAGES/client.po
@@ -1504,7 +1504,7 @@ msgid "Repeat password"
 msgstr "Ulangi sandi"
 
 #: .es5/templates/sign_up_password.mustache:6
-msgid "You need this password to access any encrypted data you store with us.<br/>A reset means potentially losing data like passwords and bookmarks."
+msgid "You need this password to access any encrypted data you store with us.<br class=\"mb-3\">A reset means potentially losing data like passwords and bookmarks."
 msgstr ""
 
 #: .es5/templates/sign_up_password.mustache:7

--- a/locale/is/LC_MESSAGES/client.po
+++ b/locale/is/LC_MESSAGES/client.po
@@ -1515,8 +1515,8 @@ msgid "Repeat password"
 msgstr "Endurtaka lykilorð"
 
 #: .es5/templates/sign_up_password.mustache:6
-msgid "You need this password to access any encrypted data you store with us.<br/>A reset means potentially losing data like passwords and bookmarks."
-msgstr "Þú þarft þetta lykilorð til að fá aðgang að öllum dulrituðum gögnum sem þú geymir hjá okkur.<br/>Endurstilling getur þýtt að þú mögulega tapir gögnum á borð við lykilorð og bókamerki."
+msgid "You need this password to access any encrypted data you store with us.<br class=\"mb-3\">A reset means potentially losing data like passwords and bookmarks."
+msgstr "Þú þarft þetta lykilorð til að fá aðgang að öllum dulrituðum gögnum sem þú geymir hjá okkur.<br class=\"mb-3\">>Endurstilling getur þýtt að þú mögulega tapir gögnum á borð við lykilorð og bókamerki."
 
 #: .es5/templates/sign_up_password.mustache:7
 msgid "Practical knowledge is coming to your inbox. Sign up for more:"

--- a/locale/it/LC_MESSAGES/client.po
+++ b/locale/it/LC_MESSAGES/client.po
@@ -1514,8 +1514,8 @@ msgid "Repeat password"
 msgstr "Ripeti password"
 
 #: .es5/templates/sign_up_password.mustache:6
-msgid "You need this password to access any encrypted data you store with us.<br/>A reset means potentially losing data like passwords and bookmarks."
-msgstr "Per accedere ai dati crittografati che memorizzi con noi, hai bisogno di questa password.<br/>Un ripristino significa potenzialmente perdere tutti i dati, come password e segnalibri."
+msgid "You need this password to access any encrypted data you store with us.<br class=\"mb-3\">A reset means potentially losing data like passwords and bookmarks."
+msgstr "Per accedere ai dati crittografati che memorizzi con noi, hai bisogno di questa password.<br class=\"mb-3\">Un ripristino significa potenzialmente perdere tutti i dati, come password e segnalibri."
 
 #: .es5/templates/sign_up_password.mustache:7
 msgid "Practical knowledge is coming to your inbox. Sign up for more:"

--- a/locale/ixl/LC_MESSAGES/client.po
+++ b/locale/ixl/LC_MESSAGES/client.po
@@ -1496,7 +1496,7 @@ msgid "Repeat password"
 msgstr ""
 
 #: .es5/templates/sign_up_password.mustache:6
-msgid "You need this password to access any encrypted data you store with us.<br/>A reset means potentially losing data like passwords and bookmarks."
+msgid "You need this password to access any encrypted data you store with us.<br class=\"mb-3\">A reset means potentially losing data like passwords and bookmarks."
 msgstr ""
 
 #: .es5/templates/sign_up_password.mustache:7

--- a/locale/ja/LC_MESSAGES/client.po
+++ b/locale/ja/LC_MESSAGES/client.po
@@ -1498,8 +1498,8 @@ msgid "Repeat password"
 msgstr "パスワードを再入力してください"
 
 #: .es5/templates/sign_up_password.mustache:6
-msgid "You need this password to access any encrypted data you store with us.<br/>A reset means potentially losing data like passwords and bookmarks."
-msgstr "このパスワードはサーバーに保存した暗号化されたデータにアクセスするのに必要です。<br/>リセットするとログイン情報やブックマークなどのデータが失われる可能性があります。"
+msgid "You need this password to access any encrypted data you store with us.<br class=\"mb-3\">A reset means potentially losing data like passwords and bookmarks."
+msgstr "このパスワードはサーバーに保存した暗号化されたデータにアクセスするのに必要です。<br class=\"mb-3\">リセットするとログイン情報やブックマークなどのデータが失われる可能性があります。"
 
 #: .es5/templates/sign_up_password.mustache:7
 msgid "Practical knowledge is coming to your inbox. Sign up for more:"

--- a/locale/ka/LC_MESSAGES/client.po
+++ b/locale/ka/LC_MESSAGES/client.po
@@ -1507,8 +1507,8 @@ msgid "Repeat password"
 msgstr "გაიმეორეთ პაროლი"
 
 #: .es5/templates/sign_up_password.mustache:6
-msgid "You need this password to access any encrypted data you store with us.<br/>A reset means potentially losing data like passwords and bookmarks."
-msgstr "თქვენ გჭირდებათ ეს პაროლი, წვდომისთვის ნებისმიერ დაშიფრულ მონაცემებთან, რომელსაც ჩვენთან ინახავთ.<br/>განულების შედეგად, პაროლები და სანიშნები დაიკარგება."
+msgid "You need this password to access any encrypted data you store with us.<br class=\"mb-3\">A reset means potentially losing data like passwords and bookmarks."
+msgstr "თქვენ გჭირდებათ ეს პაროლი, წვდომისთვის ნებისმიერ დაშიფრულ მონაცემებთან, რომელსაც ჩვენთან ინახავთ.<br class=\"mb-3\">განულების შედეგად, პაროლები და სანიშნები დაიკარგება."
 
 #: .es5/templates/sign_up_password.mustache:7
 msgid "Practical knowledge is coming to your inbox. Sign up for more:"

--- a/locale/kab/LC_MESSAGES/client.po
+++ b/locale/kab/LC_MESSAGES/client.po
@@ -1500,8 +1500,8 @@ msgid "Repeat password"
 msgstr "Sekcem tikelt nniḍen awal uffir"
 
 #: .es5/templates/sign_up_password.mustache:6
-msgid "You need this password to access any encrypted data you store with us.<br/>A reset means potentially losing data like passwords and bookmarks."
-msgstr "Tesriḍ awal-a uffir akken ad tkecmeḍ ɣer yisefka iwgelhanen akken ad teskelseḍ ɣur-neɣ.<br/>Awennez-is izmer ad d-yeglu s usruḥu n yisefka am wawalen uffiren neɣ ticraḍ n yisebtar."
+msgid "You need this password to access any encrypted data you store with us.<br class=\"mb-3\">A reset means potentially losing data like passwords and bookmarks."
+msgstr "Tesriḍ awal-a uffir akken ad tkecmeḍ ɣer yisefka iwgelhanen akken ad teskelseḍ ɣur-neɣ.<br class=\"mb-3\">Awennez-is izmer ad d-yeglu s usruḥu n yisefka am wawalen uffiren neɣ ticraḍ n yisebtar."
 
 #: .es5/templates/sign_up_password.mustache:7
 msgid "Practical knowledge is coming to your inbox. Sign up for more:"

--- a/locale/kk/LC_MESSAGES/client.po
+++ b/locale/kk/LC_MESSAGES/client.po
@@ -1502,7 +1502,7 @@ msgid "Repeat password"
 msgstr "Парольді қайталау"
 
 #: .es5/templates/sign_up_password.mustache:6
-msgid "You need this password to access any encrypted data you store with us.<br/>A reset means potentially losing data like passwords and bookmarks."
+msgid "You need this password to access any encrypted data you store with us.<br class=\"mb-3\">A reset means potentially losing data like passwords and bookmarks."
 msgstr ""
 
 #: .es5/templates/sign_up_password.mustache:7

--- a/locale/km/LC_MESSAGES/client.po
+++ b/locale/km/LC_MESSAGES/client.po
@@ -1499,7 +1499,7 @@ msgid "Repeat password"
 msgstr ""
 
 #: .es5/templates/sign_up_password.mustache:6
-msgid "You need this password to access any encrypted data you store with us.<br/>A reset means potentially losing data like passwords and bookmarks."
+msgid "You need this password to access any encrypted data you store with us.<br class=\"mb-3\">A reset means potentially losing data like passwords and bookmarks."
 msgstr ""
 
 #: .es5/templates/sign_up_password.mustache:7

--- a/locale/kn/LC_MESSAGES/client.po
+++ b/locale/kn/LC_MESSAGES/client.po
@@ -1499,7 +1499,7 @@ msgid "Repeat password"
 msgstr "ಗುಪ್ತಪದವನ್ನು ಪುನ: ಟೈಪಿಸಿ"
 
 #: .es5/templates/sign_up_password.mustache:6
-msgid "You need this password to access any encrypted data you store with us.<br/>A reset means potentially losing data like passwords and bookmarks."
+msgid "You need this password to access any encrypted data you store with us.<br class=\"mb-3\">A reset means potentially losing data like passwords and bookmarks."
 msgstr ""
 
 #: .es5/templates/sign_up_password.mustache:7

--- a/locale/ko/LC_MESSAGES/client.po
+++ b/locale/ko/LC_MESSAGES/client.po
@@ -1502,8 +1502,8 @@ msgid "Repeat password"
 msgstr "비밀번호 재입력"
 
 #: .es5/templates/sign_up_password.mustache:6
-msgid "You need this password to access any encrypted data you store with us.<br/>A reset means potentially losing data like passwords and bookmarks."
-msgstr "여기에 저장한 암호화된 데이터에 접근하기 위해서는 비밀번호가 필요합니다.<br/>재설정은 저장된 비밀번호나 북마크가 사라질 수 있음을 뜻합니다."
+msgid "You need this password to access any encrypted data you store with us.<br class=\"mb-3\">A reset means potentially losing data like passwords and bookmarks."
+msgstr "여기에 저장한 암호화된 데이터에 접근하기 위해서는 비밀번호가 필요합니다.<br class=\"mb-3\">재설정은 저장된 비밀번호나 북마크가 사라질 수 있음을 뜻합니다."
 
 #: .es5/templates/sign_up_password.mustache:7
 msgid "Practical knowledge is coming to your inbox. Sign up for more:"

--- a/locale/lt/LC_MESSAGES/client.po
+++ b/locale/lt/LC_MESSAGES/client.po
@@ -1506,7 +1506,7 @@ msgid "Repeat password"
 msgstr "Pakartokite slaptažodį"
 
 #: .es5/templates/sign_up_password.mustache:6
-msgid "You need this password to access any encrypted data you store with us.<br/>A reset means potentially losing data like passwords and bookmarks."
+msgid "You need this password to access any encrypted data you store with us.<br class=\"mb-3\">A reset means potentially losing data like passwords and bookmarks."
 msgstr ""
 
 #: .es5/templates/sign_up_password.mustache:7

--- a/locale/lus/LC_MESSAGES/client.po
+++ b/locale/lus/LC_MESSAGES/client.po
@@ -1496,7 +1496,7 @@ msgid "Repeat password"
 msgstr ""
 
 #: .es5/templates/sign_up_password.mustache:6
-msgid "You need this password to access any encrypted data you store with us.<br/>A reset means potentially losing data like passwords and bookmarks."
+msgid "You need this password to access any encrypted data you store with us.<br class=\"mb-3\">A reset means potentially losing data like passwords and bookmarks."
 msgstr ""
 
 #: .es5/templates/sign_up_password.mustache:7

--- a/locale/lv/LC_MESSAGES/client.po
+++ b/locale/lv/LC_MESSAGES/client.po
@@ -1501,7 +1501,7 @@ msgid "Repeat password"
 msgstr "Atkārtojiet paroli"
 
 #: .es5/templates/sign_up_password.mustache:6
-msgid "You need this password to access any encrypted data you store with us.<br/>A reset means potentially losing data like passwords and bookmarks."
+msgid "You need this password to access any encrypted data you store with us.<br class=\"mb-3\">A reset means potentially losing data like passwords and bookmarks."
 msgstr ""
 
 #: .es5/templates/sign_up_password.mustache:7

--- a/locale/meh/LC_MESSAGES/client.po
+++ b/locale/meh/LC_MESSAGES/client.po
@@ -1496,7 +1496,7 @@ msgid "Repeat password"
 msgstr ""
 
 #: .es5/templates/sign_up_password.mustache:6
-msgid "You need this password to access any encrypted data you store with us.<br/>A reset means potentially losing data like passwords and bookmarks."
+msgid "You need this password to access any encrypted data you store with us.<br class=\"mb-3\">A reset means potentially losing data like passwords and bookmarks."
 msgstr ""
 
 #: .es5/templates/sign_up_password.mustache:7

--- a/locale/mix/LC_MESSAGES/client.po
+++ b/locale/mix/LC_MESSAGES/client.po
@@ -1500,7 +1500,7 @@ msgid "Repeat password"
 msgstr ""
 
 #: .es5/templates/sign_up_password.mustache:6
-msgid "You need this password to access any encrypted data you store with us.<br/>A reset means potentially losing data like passwords and bookmarks."
+msgid "You need this password to access any encrypted data you store with us.<br class=\"mb-3\">A reset means potentially losing data like passwords and bookmarks."
 msgstr ""
 
 #: .es5/templates/sign_up_password.mustache:7

--- a/locale/mk/LC_MESSAGES/client.po
+++ b/locale/mk/LC_MESSAGES/client.po
@@ -1499,7 +1499,7 @@ msgid "Repeat password"
 msgstr ""
 
 #: .es5/templates/sign_up_password.mustache:6
-msgid "You need this password to access any encrypted data you store with us.<br/>A reset means potentially losing data like passwords and bookmarks."
+msgid "You need this password to access any encrypted data you store with us.<br class=\"mb-3\">A reset means potentially losing data like passwords and bookmarks."
 msgstr ""
 
 #: .es5/templates/sign_up_password.mustache:7

--- a/locale/ml/LC_MESSAGES/client.po
+++ b/locale/ml/LC_MESSAGES/client.po
@@ -1499,7 +1499,7 @@ msgid "Repeat password"
 msgstr "രഹസ്യവാക്ക് ആവർത്തിക്കുക"
 
 #: .es5/templates/sign_up_password.mustache:6
-msgid "You need this password to access any encrypted data you store with us.<br/>A reset means potentially losing data like passwords and bookmarks."
+msgid "You need this password to access any encrypted data you store with us.<br class=\"mb-3\">A reset means potentially losing data like passwords and bookmarks."
 msgstr ""
 
 #: .es5/templates/sign_up_password.mustache:7

--- a/locale/mr/LC_MESSAGES/client.po
+++ b/locale/mr/LC_MESSAGES/client.po
@@ -1499,7 +1499,7 @@ msgid "Repeat password"
 msgstr ""
 
 #: .es5/templates/sign_up_password.mustache:6
-msgid "You need this password to access any encrypted data you store with us.<br/>A reset means potentially losing data like passwords and bookmarks."
+msgid "You need this password to access any encrypted data you store with us.<br class=\"mb-3\">A reset means potentially losing data like passwords and bookmarks."
 msgstr ""
 
 #: .es5/templates/sign_up_password.mustache:7

--- a/locale/ms/LC_MESSAGES/client.po
+++ b/locale/ms/LC_MESSAGES/client.po
@@ -1503,7 +1503,7 @@ msgid "Repeat password"
 msgstr "Ulang semua kata laluan"
 
 #: .es5/templates/sign_up_password.mustache:6
-msgid "You need this password to access any encrypted data you store with us.<br/>A reset means potentially losing data like passwords and bookmarks."
+msgid "You need this password to access any encrypted data you store with us.<br class=\"mb-3\">A reset means potentially losing data like passwords and bookmarks."
 msgstr ""
 
 #: .es5/templates/sign_up_password.mustache:7

--- a/locale/my/LC_MESSAGES/client.po
+++ b/locale/my/LC_MESSAGES/client.po
@@ -1499,7 +1499,7 @@ msgid "Repeat password"
 msgstr "စကားဝှက်ပြန်ရိုက်ပါ"
 
 #: .es5/templates/sign_up_password.mustache:6
-msgid "You need this password to access any encrypted data you store with us.<br/>A reset means potentially losing data like passwords and bookmarks."
+msgid "You need this password to access any encrypted data you store with us.<br class=\"mb-3\">A reset means potentially losing data like passwords and bookmarks."
 msgstr ""
 
 #: .es5/templates/sign_up_password.mustache:7

--- a/locale/nb_NO/LC_MESSAGES/client.po
+++ b/locale/nb_NO/LC_MESSAGES/client.po
@@ -1506,8 +1506,8 @@ msgid "Repeat password"
 msgstr "Gjenta passord"
 
 #: .es5/templates/sign_up_password.mustache:6
-msgid "You need this password to access any encrypted data you store with us.<br/>A reset means potentially losing data like passwords and bookmarks."
-msgstr "Du trenger dette passordet for å få tilgang til alle krypterte data du lagrer hos oss.<br/>En tilbakestilling betyr potensielt å miste data som passord og bokmerker."
+msgid "You need this password to access any encrypted data you store with us.<br class=\"mb-3\">A reset means potentially losing data like passwords and bookmarks."
+msgstr "Du trenger dette passordet for å få tilgang til alle krypterte data du lagrer hos oss.<br class=\"mb-3\">En tilbakestilling betyr potensielt å miste data som passord og bokmerker."
 
 #: .es5/templates/sign_up_password.mustache:7
 msgid "Practical knowledge is coming to your inbox. Sign up for more:"

--- a/locale/ne_NP/LC_MESSAGES/client.po
+++ b/locale/ne_NP/LC_MESSAGES/client.po
@@ -1499,7 +1499,7 @@ msgid "Repeat password"
 msgstr ""
 
 #: .es5/templates/sign_up_password.mustache:6
-msgid "You need this password to access any encrypted data you store with us.<br/>A reset means potentially losing data like passwords and bookmarks."
+msgid "You need this password to access any encrypted data you store with us.<br class=\"mb-3\">A reset means potentially losing data like passwords and bookmarks."
 msgstr ""
 
 #: .es5/templates/sign_up_password.mustache:7

--- a/locale/nl/LC_MESSAGES/client.po
+++ b/locale/nl/LC_MESSAGES/client.po
@@ -1512,9 +1512,9 @@ msgid "Repeat password"
 msgstr "Herhaal wachtwoord"
 
 #: .es5/templates/sign_up_password.mustache:6
-msgid "You need this password to access any encrypted data you store with us.<br/>A reset means potentially losing data like passwords and bookmarks."
+msgid "You need this password to access any encrypted data you store with us.<br class=\"mb-3\">A reset means potentially losing data like passwords and bookmarks."
 msgstr ""
-"U hebt dit wachtwoord nodig om toegang te krijgen tot gecodeerde gegevens die u bij ons bewaart.<br/>Een herinitialisatie betekent mogelijk verlies van gegevens zoals wachtwoorden en bladwijzers."
+"U hebt dit wachtwoord nodig om toegang te krijgen tot gecodeerde gegevens die u bij ons bewaart.<br class=\"mb-3\">Een herinitialisatie betekent mogelijk verlies van gegevens zoals wachtwoorden en bladwijzers."
 
 #: .es5/templates/sign_up_password.mustache:7
 msgid "Practical knowledge is coming to your inbox. Sign up for more:"

--- a/locale/nn_NO/LC_MESSAGES/client.po
+++ b/locale/nn_NO/LC_MESSAGES/client.po
@@ -1502,8 +1502,8 @@ msgid "Repeat password"
 msgstr "Gjenta passord"
 
 #: .es5/templates/sign_up_password.mustache:6
-msgid "You need this password to access any encrypted data you store with us.<br/>A reset means potentially losing data like passwords and bookmarks."
-msgstr "Du treng dette passordet for å få tilgang til alle krypterte data du lagrar hos oss.<br/>Ei tilbakestilling tyder å miste data som passord og bokmerke."
+msgid "You need this password to access any encrypted data you store with us.<br class=\"mb-3\">A reset means potentially losing data like passwords and bookmarks."
+msgstr "Du treng dette passordet for å få tilgang til alle krypterte data du lagrar hos oss.<br class=\"mb-3\">>Ei tilbakestilling tyder å miste data som passord og bokmerke."
 
 #: .es5/templates/sign_up_password.mustache:7
 msgid "Practical knowledge is coming to your inbox. Sign up for more:"

--- a/locale/oc/LC_MESSAGES/client.po
+++ b/locale/oc/LC_MESSAGES/client.po
@@ -1499,7 +1499,7 @@ msgid "Repeat password"
 msgstr ""
 
 #: .es5/templates/sign_up_password.mustache:6
-msgid "You need this password to access any encrypted data you store with us.<br/>A reset means potentially losing data like passwords and bookmarks."
+msgid "You need this password to access any encrypted data you store with us.<br class=\"mb-3\">A reset means potentially losing data like passwords and bookmarks."
 msgstr ""
 
 #: .es5/templates/sign_up_password.mustache:7

--- a/locale/pa_IN/LC_MESSAGES/client.po
+++ b/locale/pa_IN/LC_MESSAGES/client.po
@@ -1501,7 +1501,7 @@ msgid "Repeat password"
 msgstr "ਪਾਸਵਰਡ ਦੁਹਰਾਉ"
 
 #: .es5/templates/sign_up_password.mustache:6
-msgid "You need this password to access any encrypted data you store with us.<br/>A reset means potentially losing data like passwords and bookmarks."
+msgid "You need this password to access any encrypted data you store with us.<br class=\"mb-3\">A reset means potentially losing data like passwords and bookmarks."
 msgstr ""
 
 #: .es5/templates/sign_up_password.mustache:7

--- a/locale/pl/LC_MESSAGES/client.po
+++ b/locale/pl/LC_MESSAGES/client.po
@@ -1512,8 +1512,8 @@ msgid "Repeat password"
 msgstr "Powtórz hasło"
 
 #: .es5/templates/sign_up_password.mustache:6
-msgid "You need this password to access any encrypted data you store with us.<br/>A reset means potentially losing data like passwords and bookmarks."
-msgstr "To hasło jest potrzebne, aby uzyskać dostęp do wszystkich zaszyfrowanych danych przechowywanych u nas.<br/>Zmiana hasła oznacza, że możliwa jest utrata danych, takich jak hasła i zakładki."
+msgid "You need this password to access any encrypted data you store with us.<br class=\"mb-3\">A reset means potentially losing data like passwords and bookmarks."
+msgstr "To hasło jest potrzebne, aby uzyskać dostęp do wszystkich zaszyfrowanych danych przechowywanych u nas.<br class=\"mb-3\">Zmiana hasła oznacza, że możliwa jest utrata danych, takich jak hasła i zakładki."
 
 #: .es5/templates/sign_up_password.mustache:7
 msgid "Practical knowledge is coming to your inbox. Sign up for more:"

--- a/locale/ppl/LC_MESSAGES/client.po
+++ b/locale/ppl/LC_MESSAGES/client.po
@@ -1500,7 +1500,7 @@ msgid "Repeat password"
 msgstr ""
 
 #: .es5/templates/sign_up_password.mustache:6
-msgid "You need this password to access any encrypted data you store with us.<br/>A reset means potentially losing data like passwords and bookmarks."
+msgid "You need this password to access any encrypted data you store with us.<br class=\"mb-3\">A reset means potentially losing data like passwords and bookmarks."
 msgstr ""
 
 #: .es5/templates/sign_up_password.mustache:7

--- a/locale/pt/LC_MESSAGES/client.po
+++ b/locale/pt/LC_MESSAGES/client.po
@@ -1507,8 +1507,8 @@ msgid "Repeat password"
 msgstr "Repita a palavra-passe"
 
 #: .es5/templates/sign_up_password.mustache:6
-msgid "You need this password to access any encrypted data you store with us.<br/>A reset means potentially losing data like passwords and bookmarks."
-msgstr "Precisa desta palavra-passe para aceder a quaisquer dados cifrados que armazene connosco. <br/>Uma reposição significa a perda potencial de dados como palavras-passe e marcadores."
+msgid "You need this password to access any encrypted data you store with us.<br class=\"mb-3\">A reset means potentially losing data like passwords and bookmarks."
+msgstr "Precisa desta palavra-passe para aceder a quaisquer dados cifrados que armazene connosco. <br class=\"mb-3\">Uma reposição significa a perda potencial de dados como palavras-passe e marcadores."
 
 #: .es5/templates/sign_up_password.mustache:7
 msgid "Practical knowledge is coming to your inbox. Sign up for more:"

--- a/locale/pt/LC_MESSAGES/client.po-e
+++ b/locale/pt/LC_MESSAGES/client.po-e
@@ -1458,8 +1458,8 @@ msgid "Repeat password"
 msgstr "Repita a palavra-passe"
 
 #: .es5/templates/sign_up_password.mustache:9
-msgid "You need this password to access any encrypted data you store with us.<br/>A reset means potentially losing data like passwords and bookmarks."
-msgstr "Precisa desta palavra-passe para aceder a quaisquer dados cifrados que armazene connosco. <br/>Uma reposição significa a perda potencial de dados como palavras-passe e marcadores."
+msgid "You need this password to access any encrypted data you store with us.<br class=\"mb-3\">A reset means potentially losing data like passwords and bookmarks."
+msgstr "Precisa desta palavra-passe para aceder a quaisquer dados cifrados que armazene connosco. <br class=\"mb-3\">Uma reposição significa a perda potencial de dados como palavras-passe e marcadores."
 
 #: .es5/templates/sign_up_password.mustache:10
 msgid "Practical knowledge is coming to your inbox. Sign up for more:"

--- a/locale/pt_BR/LC_MESSAGES/client.po
+++ b/locale/pt_BR/LC_MESSAGES/client.po
@@ -1512,8 +1512,8 @@ msgid "Repeat password"
 msgstr "Repetir senha"
 
 #: .es5/templates/sign_up_password.mustache:6
-msgid "You need this password to access any encrypted data you store with us.<br/>A reset means potentially losing data like passwords and bookmarks."
-msgstr "Você precisa dessa senha para acessar qualquer dado criptografado que armazena conosco.<br/>Redefinir significa potencialmente perder dados como senhas e favoritos."
+msgid "You need this password to access any encrypted data you store with us.<br class=\"mb-3\">A reset means potentially losing data like passwords and bookmarks."
+msgstr "Você precisa dessa senha para acessar qualquer dado criptografado que armazena conosco.<br class=\"mb-3\">Redefinir significa potencialmente perder dados como senhas e favoritos."
 
 #: .es5/templates/sign_up_password.mustache:7
 msgid "Practical knowledge is coming to your inbox. Sign up for more:"

--- a/locale/pt_PT/LC_MESSAGES/client.po
+++ b/locale/pt_PT/LC_MESSAGES/client.po
@@ -1507,8 +1507,8 @@ msgid "Repeat password"
 msgstr "Repita a palavra-passe"
 
 #: .es5/templates/sign_up_password.mustache:6
-msgid "You need this password to access any encrypted data you store with us.<br/>A reset means potentially losing data like passwords and bookmarks."
-msgstr "Precisa desta palavra-passe para aceder a quaisquer dados cifrados que armazene connosco. <br/>Uma reposição significa a perda potencial de dados como palavras-passe e marcadores."
+msgid "You need this password to access any encrypted data you store with us.<br class=\"mb-3\">A reset means potentially losing data like passwords and bookmarks."
+msgstr "Precisa desta palavra-passe para aceder a quaisquer dados cifrados que armazene connosco. <br class=\"mb-3\">Uma reposição significa a perda potencial de dados como palavras-passe e marcadores."
 
 #: .es5/templates/sign_up_password.mustache:7
 msgid "Practical knowledge is coming to your inbox. Sign up for more:"

--- a/locale/quc/LC_MESSAGES/client.po
+++ b/locale/quc/LC_MESSAGES/client.po
@@ -1500,7 +1500,7 @@ msgid "Repeat password"
 msgstr ""
 
 #: .es5/templates/sign_up_password.mustache:6
-msgid "You need this password to access any encrypted data you store with us.<br/>A reset means potentially losing data like passwords and bookmarks."
+msgid "You need this password to access any encrypted data you store with us.<br class=\"mb-3\">A reset means potentially losing data like passwords and bookmarks."
 msgstr ""
 
 #: .es5/templates/sign_up_password.mustache:7

--- a/locale/rm/LC_MESSAGES/client.po
+++ b/locale/rm/LC_MESSAGES/client.po
@@ -1508,8 +1508,8 @@ msgid "Repeat password"
 msgstr "Repeter il pled-clav"
 
 #: .es5/templates/sign_up_password.mustache:6
-msgid "You need this password to access any encrypted data you store with us.<br/>A reset means potentially losing data like passwords and bookmarks."
-msgstr "Ti dovras quest pled-clav per acceder a las datas criptadas che ti memoriseschas cun nus.<br/>Ina reinizialisaziun po muntar che datas sco pleds-clav e segnapaginas van a perder."
+msgid "You need this password to access any encrypted data you store with us.<br class=\"mb-3\">A reset means potentially losing data like passwords and bookmarks."
+msgstr "Ti dovras quest pled-clav per acceder a las datas criptadas che ti memoriseschas cun nus.<br class=\"mb-3\">Ina reinizialisaziun po muntar che datas sco pleds-clav e segnapaginas van a perder."
 
 #: .es5/templates/sign_up_password.mustache:7
 msgid "Practical knowledge is coming to your inbox. Sign up for more:"

--- a/locale/ro/LC_MESSAGES/client.po
+++ b/locale/ro/LC_MESSAGES/client.po
@@ -1512,8 +1512,8 @@ msgid "Repeat password"
 msgstr "Repetă parola"
 
 #: .es5/templates/sign_up_password.mustache:6
-msgid "You need this password to access any encrypted data you store with us.<br/>A reset means potentially losing data like passwords and bookmarks."
-msgstr "Ai nevoie de această parolă ca să accesezi orice date criptate pe care le stochezi la noi.<br/>Resetarea înseamnă o pierdere potențială de date, precum parole și marcaje."
+msgid "You need this password to access any encrypted data you store with us.<br class=\"mb-3\">A reset means potentially losing data like passwords and bookmarks."
+msgstr "Ai nevoie de această parolă ca să accesezi orice date criptate pe care le stochezi la noi.<br class=\"mb-3\">Resetarea înseamnă o pierdere potențială de date, precum parole și marcaje."
 
 #: .es5/templates/sign_up_password.mustache:7
 msgid "Practical knowledge is coming to your inbox. Sign up for more:"

--- a/locale/ru/LC_MESSAGES/client.po
+++ b/locale/ru/LC_MESSAGES/client.po
@@ -1512,8 +1512,8 @@ msgid "Repeat password"
 msgstr "Повторите пароль"
 
 #: .es5/templates/sign_up_password.mustache:6
-msgid "You need this password to access any encrypted data you store with us.<br/>A reset means potentially losing data like passwords and bookmarks."
-msgstr "Этот пароль необходим вам для доступа к любым зашифрованным данным, которые вы у нас храните.<br/>Сброс пароля повлечёт за собой потенциальную потерю таких данных, как пароли и закладки."
+msgid "You need this password to access any encrypted data you store with us.<br class=\"mb-3\">A reset means potentially losing data like passwords and bookmarks."
+msgstr "Этот пароль необходим вам для доступа к любым зашифрованным данным, которые вы у нас храните.<br class=\"mb-3\">Сброс пароля повлечёт за собой потенциальную потерю таких данных, как пароли и закладки."
 
 #: .es5/templates/sign_up_password.mustache:7
 msgid "Practical knowledge is coming to your inbox. Sign up for more:"

--- a/locale/sk/LC_MESSAGES/client.po
+++ b/locale/sk/LC_MESSAGES/client.po
@@ -1507,8 +1507,8 @@ msgid "Repeat password"
 msgstr "Zopakujte heslo"
 
 #: .es5/templates/sign_up_password.mustache:6
-msgid "You need this password to access any encrypted data you store with us.<br/>A reset means potentially losing data like passwords and bookmarks."
-msgstr "Toto heslo potrebujete na prístup k šifrovaným údajom, ktoré u nás ukladáte.<br/>Obnovenie znamená, že môžete stratiť údaje, ako sú heslá a záložky."
+msgid "You need this password to access any encrypted data you store with us.<br class=\"mb-3\">A reset means potentially losing data like passwords and bookmarks."
+msgstr "Toto heslo potrebujete na prístup k šifrovaným údajom, ktoré u nás ukladáte.<br class=\"mb-3\">Obnovenie znamená, že môžete stratiť údaje, ako sú heslá a záložky."
 
 #: .es5/templates/sign_up_password.mustache:7
 msgid "Practical knowledge is coming to your inbox. Sign up for more:"

--- a/locale/sl/LC_MESSAGES/client.po
+++ b/locale/sl/LC_MESSAGES/client.po
@@ -1509,8 +1509,8 @@ msgid "Repeat password"
 msgstr "Ponovite geslo"
 
 #: .es5/templates/sign_up_password.mustache:6
-msgid "You need this password to access any encrypted data you store with us.<br/>A reset means potentially losing data like passwords and bookmarks."
-msgstr "To geslo potrebujete za dostop do šifriranih podatkov, ki jih hranite pri nas.<br/>Ponastavitev pomeni morebitno izgubo podatkov, kot so gesla in zaznamki."
+msgid "You need this password to access any encrypted data you store with us.<br class=\"mb-3\">A reset means potentially losing data like passwords and bookmarks."
+msgstr "To geslo potrebujete za dostop do šifriranih podatkov, ki jih hranite pri nas.<br class=\"mb-3\">Ponastavitev pomeni morebitno izgubo podatkov, kot so gesla in zaznamki."
 
 #: .es5/templates/sign_up_password.mustache:7
 msgid "Practical knowledge is coming to your inbox. Sign up for more:"

--- a/locale/sq/LC_MESSAGES/client.po
+++ b/locale/sq/LC_MESSAGES/client.po
@@ -1555,8 +1555,8 @@ msgid "Repeat password"
 msgstr "Rijepeni fjalëkalimin"
 
 #: .es5/templates/sign_up_password.mustache:6
-msgid "You need this password to access any encrypted data you store with us.<br/>A reset means potentially losing data like passwords and bookmarks."
-msgstr "Ky fjalëkalim ju duhet për të hyrë në të dhëna të fshehtëzuara që depozitoni me ne.<br/>Një ricaktim do të thotë humbje potenciale të dhëna të tilla si fjalëkalime dhe faqerojtës."
+msgid "You need this password to access any encrypted data you store with us.<br class=\"mb-3\">A reset means potentially losing data like passwords and bookmarks."
+msgstr "Ky fjalëkalim ju duhet për të hyrë në të dhëna të fshehtëzuara që depozitoni me ne.<br class=\"mb-3\">Një ricaktim do të thotë humbje potenciale të dhëna të tilla si fjalëkalime dhe faqerojtës."
 
 #: .es5/templates/sign_up_password.mustache:7
 msgid "Practical knowledge is coming to your inbox. Sign up for more:"

--- a/locale/sr/LC_MESSAGES/client.po
+++ b/locale/sr/LC_MESSAGES/client.po
@@ -1503,8 +1503,8 @@ msgid "Repeat password"
 msgstr "Поновите лозинку"
 
 #: .es5/templates/sign_up_password.mustache:6
-msgid "You need this password to access any encrypted data you store with us.<br/>A reset means potentially losing data like passwords and bookmarks."
-msgstr "Ова вам је лозинка потребна за приступ шифрованим подацима које чувате код нас.<br/>Поништавање исте може резултовати губитком података попут лозинки и обележивача."
+msgid "You need this password to access any encrypted data you store with us.<br class=\"mb-3\">A reset means potentially losing data like passwords and bookmarks."
+msgstr "Ова вам је лозинка потребна за приступ шифрованим подацима које чувате код нас.<br class=\"mb-3\">Поништавање исте може резултовати губитком података попут лозинки и обележивача."
 
 #: .es5/templates/sign_up_password.mustache:7
 msgid "Practical knowledge is coming to your inbox. Sign up for more:"

--- a/locale/su/LC_MESSAGES/client.po
+++ b/locale/su/LC_MESSAGES/client.po
@@ -1504,8 +1504,8 @@ msgid "Repeat password"
 msgstr "Ulang sandi"
 
 #: .es5/templates/sign_up_password.mustache:6
-msgid "You need this password to access any encrypted data you store with us.<br/>A reset means potentially losing data like passwords and bookmarks."
-msgstr "Anjeun butuh ieu kecap sandi pikeun muka data diénkrip anu diteundeun di kami.<br/>Rését hartina bisa leungiteun data sarupaning kecap sandi jeung marka buku."
+msgid "You need this password to access any encrypted data you store with us.<br class=\"mb-3\">A reset means potentially losing data like passwords and bookmarks."
+msgstr "Anjeun butuh ieu kecap sandi pikeun muka data diénkrip anu diteundeun di kami.<br class=\"mb-3\">Rését hartina bisa leungiteun data sarupaning kecap sandi jeung marka buku."
 
 #: .es5/templates/sign_up_password.mustache:7
 msgid "Practical knowledge is coming to your inbox. Sign up for more:"

--- a/locale/sv/LC_MESSAGES/client.po
+++ b/locale/sv/LC_MESSAGES/client.po
@@ -1508,8 +1508,8 @@ msgid "Repeat password"
 msgstr "Upprepa lösenordet"
 
 #: .es5/templates/sign_up_password.mustache:6
-msgid "You need this password to access any encrypted data you store with us.<br/>A reset means potentially losing data like passwords and bookmarks."
-msgstr "Du behöver det här lösenordet för att få åtkomst till krypterad information som du lagrar hos oss.<br/>En återställning innebär att data som lösenord och bokmärken förloras."
+msgid "You need this password to access any encrypted data you store with us.<br class=\"mb-3\">A reset means potentially losing data like passwords and bookmarks."
+msgstr "Du behöver det här lösenordet för att få åtkomst till krypterad information som du lagrar hos oss.<br class=\"mb-3\">En återställning innebär att data som lösenord och bokmärken förloras."
 
 #: .es5/templates/sign_up_password.mustache:7
 msgid "Practical knowledge is coming to your inbox. Sign up for more:"

--- a/locale/sv/LC_MESSAGES/client.po-e
+++ b/locale/sv/LC_MESSAGES/client.po-e
@@ -1464,8 +1464,8 @@ msgid "Repeat password"
 msgstr "Upprepa lösenordet"
 
 #: .es5/templates/sign_up_password.mustache:9
-msgid "You need this password to access any encrypted data you store with us.<br/>A reset means potentially losing data like passwords and bookmarks."
-msgstr "Du behöver det här lösenordet för att få åtkomst till krypterad information som du lagrar hos oss.<br/>En återställning innebär att data som lösenord och bokmärken förloras."
+msgid "You need this password to access any encrypted data you store with us.<br class=\"mb-3\">A reset means potentially losing data like passwords and bookmarks."
+msgstr "Du behöver det här lösenordet för att få åtkomst till krypterad information som du lagrar hos oss.<br class=\"mb-3\">En återställning innebär att data som lösenord och bokmärken förloras."
 
 #: .es5/templates/sign_up_password.mustache:10
 msgid "Practical knowledge is coming to your inbox. Sign up for more:"

--- a/locale/sv_SE/LC_MESSAGES/client.po
+++ b/locale/sv_SE/LC_MESSAGES/client.po
@@ -1509,8 +1509,8 @@ msgid "Repeat password"
 msgstr "Upprepa lösenordet"
 
 #: .es5/templates/sign_up_password.mustache:6
-msgid "You need this password to access any encrypted data you store with us.<br/>A reset means potentially losing data like passwords and bookmarks."
-msgstr "Du behöver det här lösenordet för att få åtkomst till krypterad information som du lagrar hos oss.<br/>En återställning innebär att data som lösenord och bokmärken förloras."
+msgid "You need this password to access any encrypted data you store with us.<br class=\"mb-3\">A reset means potentially losing data like passwords and bookmarks."
+msgstr "Du behöver det här lösenordet för att få åtkomst till krypterad information som du lagrar hos oss.<br class=\"mb-3\">En återställning innebär att data som lösenord och bokmärken förloras."
 
 #: .es5/templates/sign_up_password.mustache:7
 msgid "Practical knowledge is coming to your inbox. Sign up for more:"

--- a/locale/ta/LC_MESSAGES/client.po
+++ b/locale/ta/LC_MESSAGES/client.po
@@ -1502,7 +1502,7 @@ msgid "Repeat password"
 msgstr "கடவுச்சொல்லை மீண்டும் உள்ளிடவும்"
 
 #: .es5/templates/sign_up_password.mustache:6
-msgid "You need this password to access any encrypted data you store with us.<br/>A reset means potentially losing data like passwords and bookmarks."
+msgid "You need this password to access any encrypted data you store with us.<br class=\"mb-3\">A reset means potentially losing data like passwords and bookmarks."
 msgstr ""
 
 #: .es5/templates/sign_up_password.mustache:7

--- a/locale/te/LC_MESSAGES/client.po
+++ b/locale/te/LC_MESSAGES/client.po
@@ -1499,7 +1499,7 @@ msgid "Repeat password"
 msgstr "సంకేతపదం మళ్ళీ"
 
 #: .es5/templates/sign_up_password.mustache:6
-msgid "You need this password to access any encrypted data you store with us.<br/>A reset means potentially losing data like passwords and bookmarks."
+msgid "You need this password to access any encrypted data you store with us.<br class=\"mb-3\">A reset means potentially losing data like passwords and bookmarks."
 msgstr ""
 
 #: .es5/templates/sign_up_password.mustache:7

--- a/locale/th/LC_MESSAGES/client.po
+++ b/locale/th/LC_MESSAGES/client.po
@@ -1500,8 +1500,8 @@ msgid "Repeat password"
 msgstr "ทวนรหัสผ่าน"
 
 #: .es5/templates/sign_up_password.mustache:6
-msgid "You need this password to access any encrypted data you store with us.<br/>A reset means potentially losing data like passwords and bookmarks."
-msgstr "คุณต้องใช้รหัสผ่านนี้เพื่อเข้าถึงข้อมูลใด ๆ ที่เข้ารหัสที่คุณเก็บไว้กับเรา<br/>การตั้งค่าใหม่อาจทำให้ข้อมูลต่าง ๆ เช่น รหัสผ่าน และที่คั่นหน้า สูญหาย"
+msgid "You need this password to access any encrypted data you store with us.<br class=\"mb-3\">A reset means potentially losing data like passwords and bookmarks."
+msgstr "คุณต้องใช้รหัสผ่านนี้เพื่อเข้าถึงข้อมูลใด ๆ ที่เข้ารหัสที่คุณเก็บไว้กับเรา<br class=\"mb-3\">การตั้งค่าใหม่อาจทำให้ข้อมูลต่าง ๆ เช่น รหัสผ่าน และที่คั่นหน้า สูญหาย"
 
 #: .es5/templates/sign_up_password.mustache:7
 msgid "Practical knowledge is coming to your inbox. Sign up for more:"

--- a/locale/tl/LC_MESSAGES/client.po
+++ b/locale/tl/LC_MESSAGES/client.po
@@ -1496,7 +1496,7 @@ msgid "Repeat password"
 msgstr ""
 
 #: .es5/templates/sign_up_password.mustache:6
-msgid "You need this password to access any encrypted data you store with us.<br/>A reset means potentially losing data like passwords and bookmarks."
+msgid "You need this password to access any encrypted data you store with us.<br class=\"mb-3\">A reset means potentially losing data like passwords and bookmarks."
 msgstr ""
 
 #: .es5/templates/sign_up_password.mustache:7

--- a/locale/tr/LC_MESSAGES/client.po
+++ b/locale/tr/LC_MESSAGES/client.po
@@ -1501,8 +1501,8 @@ msgid "Repeat password"
 msgstr "Parola tekrarı"
 
 #: .es5/templates/sign_up_password.mustache:6
-msgid "You need this password to access any encrypted data you store with us.<br/>A reset means potentially losing data like passwords and bookmarks."
-msgstr "Sakladığınız şifrelenmiş verilere erişmek için bu parolaya ihtiyacınız olacak.<br/>Bu parolayı sıfırlarsanız kayıtlı parolalar ve yer imleri gibi verilerinizi kaybedebilirsiniz."
+msgid "You need this password to access any encrypted data you store with us.<br class=\"mb-3\">A reset means potentially losing data like passwords and bookmarks."
+msgstr "Sakladığınız şifrelenmiş verilere erişmek için bu parolaya ihtiyacınız olacak.<br class=\"mb-3\">Bu parolayı sıfırlarsanız kayıtlı parolalar ve yer imleri gibi verilerinizi kaybedebilirsiniz."
 
 #: .es5/templates/sign_up_password.mustache:7
 msgid "Practical knowledge is coming to your inbox. Sign up for more:"

--- a/locale/trs/LC_MESSAGES/client.po
+++ b/locale/trs/LC_MESSAGES/client.po
@@ -1500,7 +1500,7 @@ msgid "Repeat password"
 msgstr ""
 
 #: .es5/templates/sign_up_password.mustache:6
-msgid "You need this password to access any encrypted data you store with us.<br/>A reset means potentially losing data like passwords and bookmarks."
+msgid "You need this password to access any encrypted data you store with us.<br class=\"mb-3\">A reset means potentially losing data like passwords and bookmarks."
 msgstr ""
 
 #: .es5/templates/sign_up_password.mustache:7

--- a/locale/tt/LC_MESSAGES/client.po
+++ b/locale/tt/LC_MESSAGES/client.po
@@ -1502,7 +1502,7 @@ msgid "Repeat password"
 msgstr "Паролны кабатлау"
 
 #: .es5/templates/sign_up_password.mustache:6
-msgid "You need this password to access any encrypted data you store with us.<br/>A reset means potentially losing data like passwords and bookmarks."
+msgid "You need this password to access any encrypted data you store with us.<br class=\"mb-3\">A reset means potentially losing data like passwords and bookmarks."
 msgstr ""
 
 #: .es5/templates/sign_up_password.mustache:7

--- a/locale/uk/LC_MESSAGES/client.po
+++ b/locale/uk/LC_MESSAGES/client.po
@@ -1511,8 +1511,8 @@ msgid "Repeat password"
 msgstr "Повторити пароль"
 
 #: .es5/templates/sign_up_password.mustache:6
-msgid "You need this password to access any encrypted data you store with us.<br/>A reset means potentially losing data like passwords and bookmarks."
-msgstr "Цей пароль необхідний для доступу до будь-яких зашифрованих даних, що зберігаються в нас.<br/>Відновлення означає потенційну втрату даних, наприклад, паролів та закладок."
+msgid "You need this password to access any encrypted data you store with us.<br class=\"mb-3\">A reset means potentially losing data like passwords and bookmarks."
+msgstr "Цей пароль необхідний для доступу до будь-яких зашифрованих даних, що зберігаються в нас.<br class=\"mb-3\">Відновлення означає потенційну втрату даних, наприклад, паролів та закладок."
 
 #: .es5/templates/sign_up_password.mustache:7
 msgid "Practical knowledge is coming to your inbox. Sign up for more:"

--- a/locale/ur/LC_MESSAGES/client.po
+++ b/locale/ur/LC_MESSAGES/client.po
@@ -1499,7 +1499,7 @@ msgid "Repeat password"
 msgstr "پاسورڈ دہرائیں"
 
 #: .es5/templates/sign_up_password.mustache:6
-msgid "You need this password to access any encrypted data you store with us.<br/>A reset means potentially losing data like passwords and bookmarks."
+msgid "You need this password to access any encrypted data you store with us.<br class=\"mb-3\">A reset means potentially losing data like passwords and bookmarks."
 msgstr ""
 
 #: .es5/templates/sign_up_password.mustache:7

--- a/locale/uz/LC_MESSAGES/client.po
+++ b/locale/uz/LC_MESSAGES/client.po
@@ -1499,7 +1499,7 @@ msgid "Repeat password"
 msgstr ""
 
 #: .es5/templates/sign_up_password.mustache:6
-msgid "You need this password to access any encrypted data you store with us.<br/>A reset means potentially losing data like passwords and bookmarks."
+msgid "You need this password to access any encrypted data you store with us.<br class=\"mb-3\">A reset means potentially losing data like passwords and bookmarks."
 msgstr ""
 
 #: .es5/templates/sign_up_password.mustache:7

--- a/locale/vi/LC_MESSAGES/client.po
+++ b/locale/vi/LC_MESSAGES/client.po
@@ -1512,8 +1512,8 @@ msgid "Repeat password"
 msgstr "Nhập lại mật khẩu"
 
 #: .es5/templates/sign_up_password.mustache:6
-msgid "You need this password to access any encrypted data you store with us.<br/>A reset means potentially losing data like passwords and bookmarks."
-msgstr "Bạn cần mật khẩu này để truy cập bất kỳ dữ liệu được mã hóa nào mà bạn lưu trữ với chúng tôi.<br/>Đặt lại có nghĩa là có khả năng mất dữ liệu như mật khẩu và dấu trang."
+msgid "You need this password to access any encrypted data you store with us.<br class=\"mb-3\">A reset means potentially losing data like passwords and bookmarks."
+msgstr "Bạn cần mật khẩu này để truy cập bất kỳ dữ liệu được mã hóa nào mà bạn lưu trữ với chúng tôi.<br class=\"mb-3\">Đặt lại có nghĩa là có khả năng mất dữ liệu như mật khẩu và dấu trang."
 
 #: .es5/templates/sign_up_password.mustache:7
 msgid "Practical knowledge is coming to your inbox. Sign up for more:"

--- a/locale/yua/LC_MESSAGES/client.po
+++ b/locale/yua/LC_MESSAGES/client.po
@@ -1500,7 +1500,7 @@ msgid "Repeat password"
 msgstr ""
 
 #: .es5/templates/sign_up_password.mustache:6
-msgid "You need this password to access any encrypted data you store with us.<br/>A reset means potentially losing data like passwords and bookmarks."
+msgid "You need this password to access any encrypted data you store with us.<br class=\"mb-3\">A reset means potentially losing data like passwords and bookmarks."
 msgstr ""
 
 #: .es5/templates/sign_up_password.mustache:7

--- a/locale/zh_CN/LC_MESSAGES/client.po
+++ b/locale/zh_CN/LC_MESSAGES/client.po
@@ -1496,8 +1496,8 @@ msgid "Repeat password"
 msgstr "再次输入密码"
 
 #: .es5/templates/sign_up_password.mustache:6
-msgid "You need this password to access any encrypted data you store with us.<br/>A reset means potentially losing data like passwords and bookmarks."
-msgstr "您需要此密码才能访问存储于云端的所有加密数据。<br/>若重置则可能会丢失密码、书签等数据。"
+msgid "You need this password to access any encrypted data you store with us.<br class=\"mb-3\">A reset means potentially losing data like passwords and bookmarks."
+msgstr "您需要此密码才能访问存储于云端的所有加密数据。<br class=\"mb-3\">若重置则可能会丢失密码、书签等数据。"
 
 #: .es5/templates/sign_up_password.mustache:7
 msgid "Practical knowledge is coming to your inbox. Sign up for more:"

--- a/locale/zh_TW/LC_MESSAGES/client.po
+++ b/locale/zh_TW/LC_MESSAGES/client.po
@@ -1498,8 +1498,8 @@ msgid "Repeat password"
 msgstr "重複輸入密碼"
 
 #: .es5/templates/sign_up_password.mustache:6
-msgid "You need this password to access any encrypted data you store with us.<br/>A reset means potentially losing data like passwords and bookmarks."
-msgstr "需要這組密碼才能解開儲存於我們這邊的加密資料。<br/>重設密碼也代表可能會失去密碼、書籤等資料。"
+msgid "You need this password to access any encrypted data you store with us.<br class=\"mb-3\">A reset means potentially losing data like passwords and bookmarks."
+msgstr "需要這組密碼才能解開儲存於我們這邊的加密資料。<br class=\"mb-3\">重設密碼也代表可能會失去密碼、書籤等資料。"
 
 #: .es5/templates/sign_up_password.mustache:7
 msgid "Practical knowledge is coming to your inbox. Sign up for more:"


### PR DESCRIPTION
In [this pull request](https://github.com/mozilla/fxa/pull/13967), we needed to add the `mb-3` class to this `br`. To help over here, I found-and-replaced the existing English string and added the class to the translated strings.

Couple questions:
1) Is this okay even if the line number changes? In our code, the line changed by 2, but I'm not sure what the output will look like until we build / if I were to run the extract script. Not sure if this matters.
2) Is this PR helpful, or would this kind of change not matter much to Pontoon/translators because the string in Pontoon's memory is almost identical? Do we have docs on how Pontoon works with strings? I have a couple of notes but, I've been meaning to update FxA's l10n docs and might have some similar questions.