### PR TITLE
Simplify fxa-settings extract strings command

### DIFF
--- a/.github/workflows/l10n_extract.yaml
+++ b/.github/workflows/l10n_extract.yaml
@@ -36,7 +36,7 @@ jobs:
         run: |
           cd fxa-code
           yarn workspaces focus fxa-content-server fxa-auth-server fxa-payments-server fxa-settings
-          yarn workspace fxa-settings build
+          yarn workspace fxa-settings grunt merge-ftl
           yarn workspace fxa-auth-server grunt merge-ftl
 
           NODE_ENV=development ../fxa-l10n/scripts/extract_strings.sh \


### PR DESCRIPTION
With [this PR and change]( https://github.com/mozilla/fxa/pull/14312/files#diff-7476db00402b40902a9cf3a6834136ed6356ae6591cb4c40a2ed99c2c0a5464fR22), we're using grunt instead of webpack to create our `settings.ftl` file. Webpack required a full build to concat our files, and while `build` still works, since it's now separate from webpack we can run the grunt task instead to make this workflow slightly faster.