### PR TITLE
feat(fxa-settings): Change fxa-settings default locale from en-US to en

### DIFF
--- a/scripts/extract_strings.sh
+++ b/scripts/extract_strings.sh
@@ -118,7 +118,7 @@ sed -i'' -e 's/Language: sv_SE/Language: sv/g' "$L10N_DIR/locale/sv/LC_MESSAGES/
 
 # Fluent extraction
 cp $PAYMENTS_DIR/public/locales/en-US/*.ftl $L10N_DIR/locale/templates
-cp $SETTINGS_DIR/public/locales/en-US/*.ftl $L10N_DIR/locale/templates
+cp $SETTINGS_DIR/public/locales/en/*.ftl $L10N_DIR/locale/templates
 cp $MAILER_DIR/public/locales/en/*.ftl $L10N_DIR/locale/templates
 
 # Pontoon will read from the "templates" directory but we must copy the FTL files


### PR DESCRIPTION
Linked to [PR-14429](https://github.com/mozilla/fxa/pull/14429)

Because:

- We are standardizing the default locale for all fxa packages to en.

This commit:

- Change the fluent extraction source from $SETTINGS_DIR/public/locales/en-US/*.ftl to $SETTINGS_DIR/public/locales/en/*.ftl

Closes #FXA-6003