### PR TITLE
add fxa-react and fxa-shared dir to workflow

### DIFF
--- a/.github/workflows/l10n_extract.yaml
+++ b/.github/workflows/l10n_extract.yaml
@@ -39,12 +39,15 @@ jobs:
           yarn workspace fxa-payments-server grunt merge-ftl
           yarn workspace fxa-settings grunt merge-ftl
           yarn workspace fxa-auth-server grunt merge-ftl
+          yarn workspace fxa-react grunt merge-ftl
 
           NODE_ENV=development ../fxa-l10n/scripts/extract_strings.sh \
             --mailer-repo ./packages/fxa-auth-server \
             --payments-repo ./packages/fxa-payments-server \
             --content-repo ./packages/fxa-content-server \
             --settings-repo ./packages/fxa-settings \
+            --react-repo ./packages/fxa-react \
+            --shared-repo ./packages/fxa-shared \
             --l10n-repo ../fxa-l10n
       - name: Commit changes and open pull request
         run: |


### PR DESCRIPTION
Because fxa-react and fxa-shared needed to be added to the workflow file to successfully extract strings from these directories.

Fixes this error in workflow:

```
Checking ./fxa-react.. Error: No such directory
Error: Process completed with exit code 1.
```