### PR TITLE
chore(l10n): call clone.sh in workflow to align with fxa script changes

### DIFF
--- a/.github/workflows/l10n_extract.yaml
+++ b/.github/workflows/l10n_extract.yaml
@@ -35,6 +35,7 @@ jobs:
       - name: Extract strings
         run: |
           cd fxa-code
+          _scripts/l10n/clone.sh
           yarn workspaces focus fxa-content-server fxa-auth-server fxa-payments-server fxa-settings
           yarn workspace fxa-payments-server grunt merge-ftl
           yarn workspace fxa-settings grunt merge-ftl


### PR DESCRIPTION
Because:
- Changes were introduced into fxa to only clone the l10n repo once via _scripts/l10n/clone.sh

This Commit:
- Updates the workflow  to call this script before the build step to extract text