### PR TITLE
feat(shared): update extract with new branding loc

### DIFF
--- a/.github/workflows/l10n_extract.yaml
+++ b/.github/workflows/l10n_extract.yaml
@@ -48,7 +48,7 @@ jobs:
             --content-repo ./packages/fxa-content-server \
             --settings-repo ./packages/fxa-settings \
             --react-repo ./packages/fxa-react \
-            --shared-repo ./packages/fxa-shared \
+            --shared-repo ./libs/shared \
             --l10n-repo ../fxa-l10n
       - name: Commit changes and open pull request
         run: |

--- a/scripts/extract_strings.sh
+++ b/scripts/extract_strings.sh
@@ -29,7 +29,7 @@ CONTENT_DIR="./fxa-content-server"
 PAYMENTS_DIR="./fxa-payments-server"
 SETTINGS_DIR="./fxa-settings"
 REACT_DIR="./fxa-react"
-SHARED_DIR="./fxa-shared"
+SHARED_DIR="../libs/shared"
 L10N_DIR="./fxa-content-server-l10n"
 
 while [[ $# > 1 ]]
@@ -136,7 +136,7 @@ cp $PAYMENTS_DIR/public/locales/en/payments.ftl $L10N_DIR/locale/templates
 cp $SETTINGS_DIR/public/locales/en/settings.ftl $L10N_DIR/locale/templates
 cp $MAILER_DIR/public/locales/en/auth.ftl $L10N_DIR/locale/templates
 cp $REACT_DIR/public/locales/en/react.ftl $L10N_DIR/locale/templates
-cp $SHARED_DIR/l10n/branding.ftl $L10N_DIR/locale/templates
+cp $SHARED_DIR/l10n/src/lib/branding.ftl $L10N_DIR/locale/templates
 
 # Pontoon will read from the "templates" directory but we must copy the FTL files
 # into "en" to ensure users with English will always see good fallback text.


### PR DESCRIPTION
Because:

* The FXA shared branding file was moved from ./packages/fxa-shared/l10n to ./libs/shared/l10n

This commit:

* Updates github workflow and extract_strings script with the new location of the shared branding ftl
* Related fxa PR is [mozilla/fxa/pull/15798](https://github.com/mozilla/fxa/pull/15798)

Closes #FXA-8228