### PR TITLE
feat(next): add support for payments-next.ftl

### DIFF
--- a/.github/workflows/l10n_extract.yaml
+++ b/.github/workflows/l10n_extract.yaml
@@ -41,10 +41,12 @@ jobs:
           yarn workspace fxa-settings grunt merge-ftl
           yarn workspace fxa-auth-server grunt merge-ftl
           yarn workspace fxa-react grunt merge-ftl
+          npx grunt --gruntfile='apps/payments/next/Gruntfile.js' merge-ftl
 
           NODE_ENV=development ../fxa-l10n/scripts/extract_strings.sh \
             --mailer-repo ./packages/fxa-auth-server \
             --payments-repo ./packages/fxa-payments-server \
+            --payments-next-repo ./apps/payments/next \
             --content-repo ./packages/fxa-content-server \
             --settings-repo ./packages/fxa-settings \
             --react-repo ./packages/fxa-react \

--- a/scripts/extract_strings.sh
+++ b/scripts/extract_strings.sh
@@ -27,6 +27,7 @@ fi
 MAILER_DIR="./fxa-auth-server"
 CONTENT_DIR="./fxa-content-server"
 PAYMENTS_DIR="./fxa-payments-server"
+PAYMENTS_NEXT_DIR="../apps/payments/next"
 SETTINGS_DIR="./fxa-settings"
 REACT_DIR="./fxa-react"
 SHARED_DIR="../libs/shared"
@@ -47,6 +48,10 @@ case $param in
     ;;
     --payments-repo)
     PAYMENTS_DIR="$2"
+    shift 2
+    ;;
+    --payments-next-repo)
+    PAYMENTS_NEXT_DIR="$2"
     shift 2
     ;;
     --settings-repo)
@@ -77,6 +82,8 @@ printf "Checking $CONTENT_DIR.. "
 check_folder $CONTENT_DIR
 printf "Checking $PAYMENTS_DIR.. "
 check_folder $PAYMENTS_DIR
+printf "Checking $PAYMENTS_NEXT_DIR.. "
+check_folder $PAYMENTS_NEXT_DIR
 printf "Checking $SETTINGS_DIR.. "
 check_folder $SETTINGS_DIR
 printf "Checking $REACT_DIR.. "
@@ -133,6 +140,7 @@ sed -i'' -e 's/Language: sv_SE/Language: sv/g' "$L10N_DIR/locale/sv/LC_MESSAGES/
 # Fluent extraction
 
 cp $PAYMENTS_DIR/public/locales/en/payments.ftl $L10N_DIR/locale/templates
+cp $PAYMENTS_NEXT_DIR/public/locales/en/payments-next.ftl $L10N_DIR/locale/templates
 cp $SETTINGS_DIR/public/locales/en/settings.ftl $L10N_DIR/locale/templates
 cp $MAILER_DIR/public/locales/en/auth.ftl $L10N_DIR/locale/templates
 cp $REACT_DIR/public/locales/en/react.ftl $L10N_DIR/locale/templates


### PR DESCRIPTION
Because:

- The Subscription Platform team is adding a new app service, payments-next, to replace the existing fxa-payments-server. In the short term both payments-next and fxa-payments-server need to be supported, each utilizing different ftl strings.

This commit:

- Adds support for new app payments-next utilizing payments-next.ftl

Closes #FXA-7482